### PR TITLE
(chocolatey/docs#76) Add Extra Layer of Navigation Styling and Additional Theme Enhancements

### DIFF
--- a/scss/_alerts.scss
+++ b/scss/_alerts.scss
@@ -7,16 +7,46 @@
 
 @each $color, $value in $theme-colors {
     .alert-#{$color} {
-        color: color-yiq($value);
-
+        transition: $theme-transition;
+        
         a {
-            color: color-yiq($value);
             font-weight: bold;
 
             &:hover {
                 text-decoration: underline;
             }
         }
+        .close {
+            text-shadow: none;
+        }
+    }
+}
+
+.alert-primary, .alert-success, .alert-danger {
+    color: $white;
+    color: var(--background);
+
+    a {
+        color: $white;
+        color: var(--background);
+    }
+}
+
+.alert-warning {
+    color: $gray-900;
+    color: var(--background);
+
+    a {
+        color: $gray-900;
+        color: var(--background);
+    }
+}
+
+.alert-secondary {
+    color: $white;
+
+    a {
+        color: $white;
     }
 }
 

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -93,7 +93,7 @@ img {
     height: auto;
 }
 
-#mainContent {
+.chocolatey-docs #mainContent {
     h1:not(.title):first-of-type {
         display: none;
     }
@@ -101,7 +101,9 @@ img {
     h2:first-of-type {
         margin-top: 0;
     }
+}
 
+#mainContent {
     a:not(.anchorjs-link):not(.btn):not(.badge) {
         padding: 14px 0;
     }
@@ -200,7 +202,7 @@ footer {
 }
 
 @include media-breakpoint-up(xl) {
-    #mainContent {
+    .chocolatey-docs  #mainContent {
         h2:first-of-type {
             margin-top: $spacer * 2;
         }

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -125,12 +125,28 @@ img {
     padding-left: $spacer * 3 - $spacer / 4 !important;
 }
 
+.pl-c375 {
+    padding-left: $spacer * 4 - $spacer / 4 !important;
+}
+
 .pl-c4 {
     padding-left: $spacer * 4 !important;
 }
 
+.pl-c475 {
+    padding-left: $spacer * 5 - $spacer / 4;
+}
+
 .pl-c5 {
     padding-left: $spacer * 5 !important;
+}
+
+.pl-c6 {
+    padding-left: $spacer * 6 !important;
+}
+
+.pl-c7 {
+    padding-left: $spacer * 7 !important;
 }
 
 /*Modals*/

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -102,7 +102,7 @@ img {
         margin-top: 0;
     }
 
-    a:not(.anchorjs-link) {
+    a:not(.anchorjs-link):not(.btn):not(.badge) {
         padding: 14px 0;
     }
 
@@ -175,11 +175,6 @@ img {
     }
 }
 
-/*Badges*/
-.badge-key {
-    font-family: $font-family-monospace;
-}
-
 /*Gitter*/
 .gitter-chat-embed, .gitter-open-chat-button {
     z-index: 9999;
@@ -198,7 +193,7 @@ footer {
     }
 
     #mainContent {
-        a:not(.anchorjs-link) {
+        a:not(.anchorjs-link):not(.btn):not(.badge) {
             padding: 0;
         }
     }

--- a/scss/_buttons-badges.scss
+++ b/scss/_buttons-badges.scss
@@ -1,0 +1,189 @@
+// General badges
+.badge-primary, .badge-success, .badge-danger {
+    color: var(--background);
+}
+
+// Custom badges
+.badge-key {
+    font-family: $font-family-monospace;
+}
+
+// Solid buttons/badges shared states
+.btn-primary, .btn-success, .btn-danger,
+a.badge-primary, a.badge-success, a.badge-danger
+{
+    color: var(--background);
+
+    &:not(:disabled):not(.disabled) {
+        &:active, &.active, &:active:focus, &.active:focus {
+            color: var(--background);
+        }
+    }
+
+    &:hover, &:focus, &.focus, &:disabled, &.disabled {
+        color: var(--background);
+    }
+}
+
+// Outline buttons shared states
+.btn-outline-primary, .btn-outline-success, .btn-outline-danger
+{
+    &:not(:disabled):not(.disabled) {
+        &:active, &.active, &:active:focus, &.active:focus {
+            color: var(--background);
+        }
+    }
+
+    &:hover {
+        color: var(--background);
+    }
+}
+
+// Outline buttons with badges
+.btn-outline-primary, .btn-outline-success, .btn-outline-danger {
+    .badge {
+        color: $white;
+        color: var(--background);
+    }
+
+    &:hover, &:active {
+        .badge {
+            background: $white;
+            background: var(--background);
+        }
+    }
+}
+
+.btn-outline-primary {
+    .badge {
+        background: $blue;
+    }
+
+    &:hover, &:active {
+        .badge {
+            color: $blue;
+        }
+    }
+}
+
+.btn-outline-danger {
+    .badge {
+        background: $red;
+    }
+
+    &:hover, &:active {
+        .badge {
+            color: $red;
+        }
+    }
+}
+
+.btn-outline-success {
+    .badge {
+        background: $green;
+    }
+
+    &:hover, &:active {
+        .badge {
+            color: $green;
+        }
+    }
+}
+
+.btn-outline-warning {
+    .badge {
+        background: $yellow;
+        color: $gray-900;
+    }
+
+    &:hover, &:active {
+        .badge {
+            background: $gray-900;
+            color: $yellow;
+        }
+    }
+}
+
+.btn-outline-secondary {
+    .badge {
+        background: $gray-600;
+        color: $white;
+    }
+
+    &:hover, &:active {
+        .badge {
+            background: $white;
+            color: $gray-600;
+        }
+    }
+}
+
+// Solid buttons with badges
+.btn-primary, .btn-success, .btn-danger {
+    .badge {
+        background: $white;
+        background: var(--background);
+    }
+}
+
+.btn-primary {
+    .badge {
+        color: $blue;
+    }
+
+    &:hover, &:active, &:focus {
+        .badge {
+            color: darken($blue, 7.5%);
+        }
+    }
+}
+
+.btn-success {
+    .badge {
+        color: $green;
+    }
+
+    &:hover, &:active, &:focus {
+        .badge {
+            color: darken($green, 7.5%);
+        }
+    }
+}
+
+.btn-danger {
+    .badge {
+        color: $red;
+    }
+
+    &:hover, &:active, &:focus {
+        .badge {
+            color: darken($red, 7.5%);
+        }
+    }
+}
+
+.btn-warning {
+    .badge {
+        background: $gray-900;
+        color: $yellow;
+    }
+
+    &:hover, &:active, &:focus {
+        .badge {
+            color: darken($yellow, 7.5%);
+        }
+    }
+}
+
+.btn-secondary {
+    .badge {
+        background: $white;
+        color: $gray-600;
+    }
+
+    &:hover, &:active, &:focus {
+        .badge {
+            color: darken($gray-600, 7.5%);
+        }
+    }
+}

--- a/scss/_left-navigation.scss
+++ b/scss/_left-navigation.scss
@@ -105,8 +105,38 @@
                                                 > .navbar-nav {
                                                     > .nav-item {
                                                         > .nav-link {
+                                                            &.nav-link-collapse .btn-collapse {
+                                                                padding-left: $spacer * 4 - $spacer / 4;
+                                                            }
+            
                                                             &:not(.nav-link-collapse) {
                                                                 padding-left: $spacer * 5;
+                                                            }
+                                                        }
+                                                        > .collapse {
+                                                            > .navbar-nav {
+                                                                > .nav-item {
+                                                                    > .nav-link {
+                                                                        &.nav-link-collapse .btn-collapse {
+                                                                            padding-left: $spacer * 5 - $spacer / 4;
+                                                                        }
+
+                                                                        &:not(.nav-link-collapse) {
+                                                                            padding-left: $spacer * 6;
+                                                                        }
+                                                                    }
+                                                                    > .collapse {
+                                                                        > .navbar-nav {
+                                                                            > .nav-item {
+                                                                                > .nav-link {
+                                                                                    &:not(.nav-link-collapse) {
+                                                                                        padding-left: $spacer * 7;
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     }

--- a/scss/_top-navigation.scss
+++ b/scss/_top-navigation.scss
@@ -169,6 +169,18 @@
                 &:nth-last-child(2) {
                     padding-right: 1rem;
                 }
+
+                .nav-link {
+                    font-weight: bold;
+                }
+            }
+        }
+
+        .navbar-collapse {
+            .navbar-nav {
+                .nav-item {
+                    padding-right: $spacer * 2;
+                }
             }
         }
 

--- a/scss/chocolatey.scss
+++ b/scss/chocolatey.scss
@@ -19,6 +19,7 @@
 @import "alerts";
 @import "blockquotes";
 @import "cards";
+@import "buttons-badges";
 @import "prism";
 @import "icons";
 @import "inputs";


### PR DESCRIPTION
In this PR:

* Adds styling to facilitate an extra layer of navigation to the left side of the docs subdomain. In addition, support has been added to allow for an extra layer, in case one is added in the future.
* Styles buttons, badges, and alerts to better fit the dark/light theme
* Contains certain css to docs subdomain
* Adds support for collapsable top nav 

Fixes styling for https://github.com/chocolatey/docs/issues/76
