### PR TITLE
(build) Pin Bootstrap Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@popperjs/core": "^2.6.0",
     "anchor-js": "^4.3.0",
-    "bootstrap": "^5.0.0-beta1",
+    "bootstrap": "5.0.0-beta1",
     "clipboard": "^2.0.6",
     "docsearch.js": "^2.6.3",
     "easymde": "^2.13.0",


### PR DESCRIPTION
Bootstrap has been updated from beta1 to beta2, however there are build
issues in Bootstrap 5 Beta2 in the alerts.js. For now, pinning choco-theme
to Beta1 until bugs are fixed in the updated version.

For pinning see: https://stackoverflow.com/a/25861938/10430540