### PR TITLE
Update stats.js and social links

### DIFF
--- a/js/chocolatey-stats.js
+++ b/js/chocolatey-stats.js
@@ -1,4 +1,6 @@
-jQuery(getStats);
+if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1" && location.hostname !== "") {
+    jQuery(getStats);
+}
 
 function getStats(currData) {
     currData = currData || {};

--- a/partials/socialmedia.txt
+++ b/partials/socialmedia.txt
@@ -41,4 +41,18 @@
             </div>
         </a>
     </li>
+    <li class="list-inline-item">
+        <a href="https://gitter.im/chocolatey/chocolatey.org" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Gitter">
+            <div class="bg-gitter circle" aria-hidden="true">
+                <i class="fab fa-gitter"></i>
+            </div>
+        </a>
+    </li>
+    <li class="list-inline-item">
+        <a href="https://groups.google.com/forum/#!forum/chocolatey" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Google Groups">
+            <div class="bg-google circle" aria-hidden="true">
+                <i class="fab fa-google"></i>
+            </div>
+        </a>
+    </li>
 </ul>

--- a/scss/_chocolatey-variables.scss
+++ b/scss/_chocolatey-variables.scss
@@ -32,6 +32,8 @@ $linkedin:  #0073b1;
 $github:    $gray-900;
 $facebook:  #1877f2;
 $rss:       $orange;
+$gitter:    #d22e57;
+$google:    #4285F4;
 
 // Theme
 $primary:      $blue;
@@ -173,7 +175,9 @@ $socialmedia-colors: (
   linkedin: $linkedin,
   github:   $github,
   facebook: $facebook,
-  rss:      $rss   
+  rss:      $rss,
+  gitter:   $gitter,
+  google:   $google
 );
 
 $palette-colors: (


### PR DESCRIPTION
In this PR:

*  Updates the stats.js to only pull stats when not on local host (removes js errors locally)
*  Adds social links into socialmedia partial (used on chocolatey.org only currently)