### PR TITLE
(code) Allow pre to be used without code format

### DIFF
--- a/js/chocolatey-code.js
+++ b/js/chocolatey-code.js
@@ -4,7 +4,7 @@
     codeBlocks.forEach(trimString);
 
     // Highlight code blocks
-    if (!jQuery('pre').hasClass('highlight-delay')) {
+    if (!jQuery('pre').hasClass('highlight-delay') && !jQuery('pre').hasClass('d-format-none')) {
         jQuery('pre').addClass('line-numbers py-2');
         jQuery('pre:not([class*="language-"])').addClass('language-none');
         Prism.highlightAll();

--- a/scss/_prism.scss
+++ b/scss/_prism.scss
@@ -2,6 +2,11 @@ code {
 	font-weight: bold;
 }
 
+pre.d-format-none {
+	font-family: $font-family-sans-serif;
+	font-size: $font-size-base;
+}
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: var(--text-code);


### PR DESCRIPTION
This allows the pre tag to be used to display text information that may
be pulled out of a DB using JS. It will allow the text to keep its
formatting and not look like a code block.