### PR TITLE
(packages) Update Icon Backgrounds

### DIFF
--- a/scss/_packages.scss
+++ b/scss/_packages.scss
@@ -13,6 +13,10 @@
     width: 50px;
     max-width: 50px;
     min-width: 50px;
+
+    img {
+        max-height: 30px;
+    }
 }
 
 .package-icon {


### PR DESCRIPTION
In some rare occurrences, the backgrounds on the icons would appear
rectangular instead of square. This will ensure all icons appear as
square, and the logo fits inside it.