### PR TITLE
Add URL Hash and Navigation to Tabbed/Collapsed Elements

### DIFF
--- a/js/chocolatey-collapse-nested.js
+++ b/js/chocolatey-collapse-nested.js
@@ -1,6 +1,8 @@
 (function() {
     nestedCollapseLocation();
-    window.onhashchange = nestedCollapseLocation;
+    nestedTabLocation();
+    //window.onhashchange = nestedCollapseLocation;
+    //window.onhashchange = nestedTabLocation;
 
     function nestedCollapseLocation() {
         if (location.hash) {
@@ -33,6 +35,37 @@
         }
     }
 
+    function nestedTabLocation() {
+        if (location.hash) {
+            var el = document.querySelector('[data-bs-toggle="tab"][href="' + escapeId(location.hash) + '"]');
+            
+            if (el) {               
+                var elScroll = el,
+                    tabParents = getParents(el).filter(el => el != document && el.classList.contains('tab-pane'));
+
+                tabParents.push(el);
+
+                tabParents.reverse().forEach(function (el, idx, array) {
+                    if (!el.id.includes('-tab')) {
+                        el = document.getElementById(escapeId(el.id) + '-tab');
+                    }
+
+                    var tabParentContainer = Tab.getInstance(el) ? Tab.getInstance(el) : new Tab(el, { toggle: false });
+                    
+                    tabParentContainer.show();
+
+                    el.addEventListener('shown.bs.tab', function (e) {
+                        e.stopImmediatePropagation();
+
+                        if (idx === array.length - 1){
+                            elScroll.scrollIntoView();
+                        }
+                    });
+                });
+            }
+        }
+    }
+
     var btnCollapseTarget = document.querySelectorAll('.btn-collapse-target');
     if (btnCollapseTarget) {
         btnCollapseTarget.forEach(function (el) {
@@ -41,7 +74,25 @@
                     collapseTargetContainer = Collapse.getInstance(collapseTarget) ? Collapse.getInstance(collapseTarget) : new Collapse(collapseTarget, { toggle: false });
 
                 collapseTargetContainer.show();
-            });
+            }, false);
+        });
+    }
+
+    document.querySelectorAll('[data-bs-toggle="tab"]:not(.d-hash-none)').forEach(function (el) {
+        changeHash(el);
+    });
+
+    document.querySelectorAll('[data-bs-toggle="collapse"]:not(.d-hash-none)').forEach(function (el) {
+        changeHash(el);
+    });
+
+    function changeHash(el) {
+        el.addEventListener('click', function (e) {
+            if (history.pushState) {
+                history.pushState(null, null, e.target.hash);
+            } else {
+                window.location.hash = e.target.hash; //Polyfill for old browsers
+            }
         });
     }
 })();

--- a/scss/_jotforms.scss
+++ b/scss/_jotforms.scss
@@ -91,3 +91,7 @@ li.form-line:not(.form-line-column) .form-input-wide[data-layout=half] {
     background: #5c9fda;
     border-color: #5c9fda;
 }
+
+.form-captcha {
+    background: none;
+}


### PR DESCRIPTION
* Minor update to form css
* This adds back in previous functionality that changes the url hash when
a collapsed/tabbed element is clicked on. When navigating to a url that
contains a hash, the JS will look to see if the hash is a
collapsed/tabbed item, and if so it will open the collapse/tabbed
element to be viewed.