### PR TITLE
(theme) Provide Utility for No Text Transform

### DIFF
--- a/scss/_packages.scss
+++ b/scss/_packages.scss
@@ -112,6 +112,11 @@
     opacity: .6;
 }
 
+// Description
+.chocolatey-org #description h1 {
+    text-transform: none;
+}
+
 // Easy MDE Editor
 .EasyMDEContainer {
     .editor-toolbar {

--- a/scss/_text.scss
+++ b/scss/_text.scss
@@ -45,3 +45,7 @@
     color: var(--text);
     fill: var(--text);
 }
+
+.text-transform-none {
+    text-transform: none !important;
+}


### PR DESCRIPTION
This provides a utility to remove any text transforms that may have
been applied globally. Any `<h1>` elements within a package description
have also had the text transform to uppercase removed.