### PR TITLE
(chocolatey/home#29) Update Code Block Trimming

### DIFF
--- a/js/chocolatey-functions.js
+++ b/js/chocolatey-functions.js
@@ -52,6 +52,6 @@
 
     // Trims off spaces from the beginning and end of a string and replaces it
     window.trimString=function(item) {
-        return item.innerHTML = item.innerHTML.replace(item.innerHTML, item.innerHTML.trim());
+        return item.innerHTML = item.innerHTML.trim();
     }
 })();


### PR DESCRIPTION
The function above was causing characters with the pattern of `$'` to
be replaced. The function has been simplified and the error removed. Now
this function will simply trim any extra spaces from the
very end/beginning of a code block (as it was intended).