### PR TITLE
(theme) Adjust z-index on easyMDE Editors

### DIFF
--- a/scss/_packages.scss
+++ b/scss/_packages.scss
@@ -157,6 +157,10 @@
         .CodeMirror-cursor {
             border-left: 1px solid var(--text);
         }
+
+        .CodeMirror-placeholder.CodeMirror-line-like {
+            z-index: 9 !important;
+        }
     }
 
     .CodeMirror-wrap pre.CodeMirror-line, .CodeMirror-wrap pre.CodeMirror-line-like {


### PR DESCRIPTION
Adjust the z-index on text editors that utilize the easyMDE library to
enable showing of placeholder text.