### PR TITLE
(community) Add Missing Colors into Status Icons

### DIFF
--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -96,7 +96,7 @@
             background: $red;
         }
 
-        .status-pending, .status-flagged-note, .status-pending-none {
+        .status-pending, .status-flagged-note, .status-pending-none, .status-pending-unknown {
             background: $yellow;
         }
 
@@ -104,7 +104,7 @@
             background: $green;
         }
 
-        .status-exempted, .status-unknown, .status-exempted-none, .status-unknown-none {
+        .status-exempted, .status-unknown, .status-exempted-none, .status-unknown-none, .status-exempted-unknown, .status-flagged-unknown {
             background: $secondary;
         }
 


### PR DESCRIPTION
Adds a few missing classes to define background colors on status ball
icons.