### PR TITLE
(events) Show Upcoming Time in Local/GMT

### DIFF
--- a/js/chocolatey-functions.js
+++ b/js/chocolatey-functions.js
@@ -54,4 +54,41 @@
     window.trimString=function(item) {
         return item.innerHTML = item.innerHTML.trim();
     }
+
+    // Convert event time to local/utc
+    var convertEventTimeToLocal = document.querySelectorAll('.convert-utc-to-local');
+    convertEventTimeToLocal.forEach(function (el) {
+        var timeIncludeBreak = el.getAttribute('data-event-include-break'),
+            timeOccurrence = el.getAttribute('data-event-occurrence'),
+            utcTime = el.getAttribute('data-event-utc').split(' '),
+            datePart = utcTime[0].split('/'),
+            timePart = utcTime[1].split(':'),
+            utcDateTime = luxon.DateTime.utc(parseInt(datePart[2]), parseInt(datePart[0]), parseInt(datePart[1]), parseInt(timePart[0]), parseInt(timePart[1]), parseInt(timePart[2])),
+            timeIncludeBreakText,
+            timeOccurrenceText;
+
+        if (timeIncludeBreak == 'true') {
+            timeIncludeBreakText = '<br />'
+        } else {
+            timeIncludeBreakText = 'at ';
+        }
+
+        switch (timeOccurrence) {
+            case "0":
+                timeOccurrenceText = 'Every ' + utcDateTime.toLocal().toFormat('cccc') + ' ' + timeIncludeBreakText;
+                break;
+            case "1":
+                timeOccurrenceText = 'First ' + utcDateTime.toLocal().toFormat('cccc') +  ' of Every Month ' + timeIncludeBreakText;
+                break;
+            default:
+                timeOccurrenceText = '';
+        }
+
+        if (timeOccurrence) {
+            el.innerHTML = timeOccurrenceText + utcDateTime.toLocal().toFormat("h:mm a ZZZZ") + ' / ' + utcDateTime.toFormat("h:mm a 'GMT'");
+            return;
+        }
+
+        el.innerText = utcDateTime.toLocal().toFormat("cccc, dd LLL yyyy 'at' h:mm a ZZZZ");
+    });
 })();

--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -101,7 +101,7 @@
         <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank">
             <img class="img-fluid mb-3" src="https://chocolatey.org/assets/images/events/04-00.jpg" alt="Chocolatey Explained - Monthly Twitch Stream" />
         </a>
-        <p><strong>First Thursday of Every Month<br />5 PM BST/GMT+1 / 6 PM CEST / 11 AM CDT / 12 AM EDT</strong></p>
+        <p class="convert-utc-to-local fw-bold" data-event-utc='06/03/2021 16:00:00' data-event-occurrence="1" data-event-include-break="true"></p>
         <p class="text-start">Join us on the first Thursday of every month for "Chocolatey Explained" where we will cover different Chocolatey topics in detail.</p>
         <a href="https://www.twitch.tv/chocolateysoftware" class="btn bg-twitch text-white btn-width mt-2" target="_blank" rel="nofollow"><i class="fab fa-twitch"></i> Follow on Twitch</a>
         <hr />
@@ -110,7 +110,7 @@
         <a href="https://chocolatey.zoom.us/webinar/register/WN_U2jxz5LSRUaReaMGbHBHJw" rel="noreferrer" target="_blank">
             <img class="img-fluid mb-3" src="https://chocolatey.org/assets/images/events/04-01.jpg" alt="Chocolatey for Business Overview and Demonstration" />
         </a>
-        <p><strong>Every Thursday<br />1 PM CDT / 11 AM PDT / 8 PM CET</strong></p>
+        <p class="convert-utc-to-local fw-bold" data-event-utc='05/27/2021 18:00:00' data-event-occurrence="0" data-event-include-break="true"></p>
         <p class="text-start">
             This session is meant to provide attendees with a better understanding of how Chocolatey has helped in an organizational setting, 
             and educate on the features included in Chocolatey for Business that can help your team more effectively manage its software.


### PR DESCRIPTION
This will show upcoming events with two times. One time is the users
local time, and the other is the time converted to GMT (UTC). This
helps the user understand what time the event is without having to
convert the time on their own.