### PR TITLE
(build) Pin easymde to v2.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clipboard": "^2.0.6",
     "datatables.net": "^1.10.24",
     "docsearch.js": "^2.6.3",
-    "easymde": "^2.13.0",
+    "easymde": "2.13.0",
     "flatpickr": "^4.6.9",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",


### PR DESCRIPTION
The easymde package needs to be pinned to version 2.13.0. This is
due to the fact that newer versions have a dependency on the package
"types/marked v2.0.3" which depends on a higher version of node than
what is installed on Appharbor. Pinning easymde to version 2.13.0 only
depends on "types/marked v1.2.3" which is supported by the currently
installed version of node.