### PR TITLE
(build) Upgrade Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
     "mousetrap": "^1.6.5",
     "node-sass": "^6.0.1"
   },
+  "resolutions": {
+    "glob-parent": "^6.0.1",
+    "yargs-parser": "^20.2.9"
+  },
   "devDependencies": {}
 }


### PR DESCRIPTION
Forces upgrade of dependencies:
* glob-parent
* yargs-parser

This adds what are called "resolutions" to the package.json files. What
this does is force dependencies from other packages to specific
versions. These two packages were raising security vulnerabilities,
with the parent package being gulp itself. With no update to gulp for a
patch, the dependencies needed to be upgrade manually.

More info found below:
https://classic.yarnpkg.com/en/docs/selective-version-resolutions/