### PR TITLE
(packages) Add Color for Scan Exemption Note

### DIFF
--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -104,7 +104,7 @@
             background: $green;
         }
 
-        .status-exempted, .status-unknown, .status-exempted-none, .status-unknown-none, .status-exempted-unknown, .status-unknown-unknown {
+        .status-exempted, .status-unknown, .status-exempted-none, .status-unknown-none, .status-exempted-unknown, .status-unknown-unknown, .status-exempted-note {
             background: $secondary;
         }
 


### PR DESCRIPTION
The newest release of Chocolatey has the scanner status of exempted with
a note. This type of status has not been accounted for in the css, and
the icon next to the package did not have a color. The appropriate gray
color has been added for the sliver of the icon, which matches the
exempted icon in on the package page.