### PR TITLE
(packages) Add Color for Investigate Note

### DIFF
--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -92,7 +92,7 @@
             padding-top: 20px;
         }
 
-        .status-failing, .status-flagged-error, .status-investigate-none, .status-scannerexempted-none, .status-investigate-unknown, .status-scannerexempted-unknown {
+        .status-failing, .status-flagged-error, .status-investigate-none, .status-scannerexempted-none, .status-investigate-unknown, .status-scannerexempted-unknown, .status-investigate-note {
             background: $red;
         }
 


### PR DESCRIPTION
The newest release of Chocolatey has the scanner status of investigate
with a note. This type of status has not been accounted for in the css,
and the icon next to the package did not have a color. The appropriate
red color has been added for the sliver of the icon, which matches the
icon in on the package page.