### PR TITLE
(events) Remove C4B Training from Flyout

### DIFF
--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -44,19 +44,6 @@
     <a href="https://blueprintldn.com/business/chocolatey/" rel="noreferrer" target="_blank" class="btn btn-primary btn-width mt-2">Register</a>
     <hr />
 </div>
-<div class="text-center">
-    <a href="https://chocolatey.zoom.us/webinar/register/WN_oWCsMuQYQAy5FcbYQkqNVA" rel="noreferrer" target="_blank">
-        <img class="img-fluid mb-3" src="https://chocolatey.org/assets/images/events/04-01.jpg" alt="Chocolatey for Business Overview and Demonstration" />
-    </a>
-    <p class="convert-utc-to-local fw-bold" data-event-utc='09/16/2021 15:00:00' data-event-include-break="true"></p>
-    <p class="text-start">
-        This session is meant to provide attendees with a better understanding of how Chocolatey has helped in an organizational setting, 
-        and educate on the features included in Chocolatey for Business that can help your team more effectively manage its software.
-    </p>
-    <a href="https://chocolatey.org/events/chocolatey-for-business-overview-and-demonstration" class="btn btn-outline-primary btn-width mt-2">Learn More</a>
-    <a href="https://chocolatey.zoom.us/webinar/register/WN_oWCsMuQYQAy5FcbYQkqNVA" rel="noreferrer" target="_blank" class="btn btn-primary btn-width mt-2">Register</a>
-    <hr />
-</div>
 <div class="shuffle">
     <div class="text-center">
         <a href="https://chocolatey.zoom.us/webinar/register/WN_3llbuDHORCuexvvR0d8naA" rel="noreferrer" target="_blank">


### PR DESCRIPTION
This removes the C4B training webinar from the flyout since the
time/date/link is expired.