### PR TITLE
(build) Upgrade Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   },
   "resolutions": {
     "glob-parent": "^6.0.1",
-    "yargs-parser": "^20.2.9"
+    "yargs-parser": "^20.2.9",
+    "ansi-regex": "^5.0.1",
+    "set-value": "^4.0.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Forces upgrade of dependencies:
* ansi-regex
* set-value

This adds what are called "resolutions" to the package.json files. What
this does is force dependencies from other packages to specific
versions. These two packages were raising security vulnerabilities,
with the parent packages being gulp and yarn themselves.

More info found below:
https://classic.yarnpkg.com/en/docs/selective-version-resolutions/