### PR TITLE
(events) Remove AnsibleFest Top Banner

### DIFF
--- a/partials/AlertText.txt
+++ b/partials/AlertText.txt
@@ -1,1 +1,0 @@
-<a href='https://events.ansiblefest.redhat.com/widget/redhat/ansible21/exhcatalog/exhibitor/1629399510356001vQre' target='_blank'>Join us virtually at AnsibleFest September 29-30!</a>


### PR DESCRIPTION
AnsibleFest is now over, which means the top banner needs to be
removed. By removing the text from this partial, it will remove the
banner from the sites when choco-theme is upgraded.