### PR TITLE
(script builder) Remove "--pre" from Title

### DIFF
--- a/js/chocolatey-script-builder.js
+++ b/js/chocolatey-script-builder.js
@@ -299,8 +299,8 @@
     }
 
     function findScriptValue(scriptValue) {
-        if (scriptValue.indexOf('--version') > 0) {
-            scriptValue = scriptValue.split('--version');
+        if (scriptValue.indexOf('--') > 0) {
+            scriptValue = scriptValue.split('--');
             scriptValue = scriptValue[0].trim();
         }
 


### PR DESCRIPTION
Currently, if a package is added to Script Builder that has the --pre
flag, it is being added to the title of the package in the generated
script. This ensures that the value is pulled out from the start of the
first `--` character and split, regardless of what flag is listed.