### PR TITLE
(script builder)  Add onerror Image

### DIFF
--- a/js/chocolatey-script-builder.js
+++ b/js/chocolatey-script-builder.js
@@ -83,7 +83,7 @@
                 '<div id="' + packageIdentity + '" class="d-flex flex-row align-items-start storage-row ' + packageIdentity + '">' +
                 '<div class="ratio ratio-1x1 package-image-header">' +
                 '<div class="d-flex flex-fill align-items-center justify-content-center package-icon">' +
-                '<img class="package-image" src="' + packageImagePath + '' + packageImage + '" height="30" width="30">' +
+                '<img class="package-image" src="' + packageImagePath + '' + packageImage + '" height="30" width="30" onerror="this.src=\'/Content/Images/packageDefaultIcon-50x50.png\'">' +
                 '</div>' +
                 '</div>' +
                 '<div class="mx-2">' +


### PR DESCRIPTION
This adds a backup onerror image for when the image chosen for a
package has a broken path. This is the same icon/logic that is used in
the cshtml on the package page.