### PR TITLE
(banner) Add Log4j Alert Banner

### DIFF
--- a/partials/AlertText.txt
+++ b/partials/AlertText.txt
@@ -1,0 +1,1 @@
+Chocolatey products not vulnerable to Log4j. <a href='https://blog.chocolatey.org/2021/12/chocolatey-products-not-affected-by-log4j-vulnerability/'>Read our announcement.</a>


### PR DESCRIPTION
This adds an alert top banner to link to the Log4J blog post.

![Screen Shot 2021-12-15 at 8 00 19 AM](https://user-images.githubusercontent.com/42750725/146200131-927a7cdc-4e04-4d17-8e69-6f10337102c2.png)
