### PR TITLE
(#122) Update and Move Tab CSS

### DIFF
--- a/scss/_script-builder.scss
+++ b/scss/_script-builder.scss
@@ -132,53 +132,6 @@
     }
 }
 
-.nav-tabs-install {
-    display: flex;
-    justify-content: center;
-    border-bottom: none;
-
-    .nav-item {
-        margin: 15px;
-
-        .nav-link {
-            height: 100px;
-            align-items: center;
-            display: flex;
-            margin: 0 !important;
-            border: 5px solid var(--border);
-            background: $white;
-            border-radius: .25rem;
-            border-radius: unset;
-            font-weight: bold;
-            transition: .5s ease;
-
-            &:hover, &.active {
-                border: 5px solid $primary;
-                color: $dark;
-                //box-shadow: $box-shadow;
-            }
-
-            .nav-img {
-                height: 60px !important;
-            }
-        }
-    }
-
-    &.nav-tabs-install-package {
-        .nav-item {
-            margin: 10px;
-
-            .nav-link {
-                height: 90px;
-
-                .nav-img {
-                    height: 50px !important;
-                }
-            }
-        }
-    }
-}
-
 @include media-breakpoint-up(sm) {
     #Modal_ScriptBuilder .modal-dialog {
         max-width: 667px !important;

--- a/scss/_tabs.scss
+++ b/scss/_tabs.scss
@@ -1,0 +1,70 @@
+.nav-tabs-image-boxes {
+    display: flex;
+    justify-content: center;
+    border-bottom: none;
+
+    .nav-item {
+        margin: 15px;
+
+        .nav-link {
+            height: 100px;
+            align-items: center;
+            display: flex;
+            margin: 0 !important;
+            border: 5px solid var(--border);
+            background: $white;
+            border-radius: .25rem;
+            border-radius: unset;
+            font-weight: bold;
+            transition: .5s ease;
+
+            &:hover, &.active {
+                border: 5px solid $primary;
+                color: $dark;
+                //box-shadow: $box-shadow;
+            }
+
+            .nav-img {
+                height: 60px !important;
+            }
+        }
+    }
+
+    &.nav-tabs-image-boxes-md {
+        .nav-item {
+            margin: 10px;
+
+            .nav-link {
+                height: 90px;
+
+                .nav-img {
+                    height: 50px !important;
+                }
+            }
+        }
+    }
+
+    &.nav-tabs-image-boxes-sm {
+        .nav-item {
+            margin: 5px;
+
+            .nav-link {
+                height: 50px;
+
+                .nav-img {
+                    height: 25px !important;
+                }
+            }
+        }
+    }
+
+    &.nav-tabs-opacity {
+        .nav-link {
+            opacity: .3;
+
+            &.active {
+                opacity: 1;
+            }
+        }
+    }
+}

--- a/scss/chocolatey.scss
+++ b/scss/chocolatey.scss
@@ -46,4 +46,5 @@
 @import "datatables";
 @import "pagination";
 @import "chartist";
+@import "tabs";
 @import "ie";


### PR DESCRIPTION
## Description Of Changes
This first moves the current tab css out of the main Script Builder
css, since these styles can be used on other parts of the website other
then Script Builder.

A new file has been created specifically for tabs styles. The class
names have been updated to be more generic and reusable across
components in multiple areas. Sizing classes have been introduced so
that everything stays the same except for the size of the tabs image
box.

## Motivation and Context
The icons are too large and don't look good on smaller screens. 

## Testing
1. Tested on community.chocolatey.org and on chocolatey.org. Linked choco-theme and built the preview website.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/chocolatey.org/issues/101
* https://github.com/chocolatey/home/issues/89
* https://github.com/chocolatey/choco-theme/issues/122

Fixes #122 
