### PR TITLE
(#127) CSS to Support Author Card on Blog

### DIFF
--- a/scss/_curve.scss
+++ b/scss/_curve.scss
@@ -47,6 +47,11 @@
     }
 }
 
+.slant-top-end {
+    -webkit-clip-path: polygon(0 0, 100% 0, 100% 0, 0 100%);
+    clip-path: polygon(0 0, 100% 0, 100% 0, 0 100%);
+}
+
 @include media-breakpoint-up(lg) {
     .curve {
         height: 80px;

--- a/scss/_lists.scss
+++ b/scss/_lists.scss
@@ -16,6 +16,10 @@
     .list-inline-item {
         margin-bottom: $spacer / 4;
     }
+
+    .list-inline-item-lg:not(:last-child) {
+        margin-right: $spacer * 2;
+    }
 }
 
 .list-hr > li:not(:last-child) {

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -68,6 +68,10 @@
     margin-left: 30px;
 }
 
+.mt-nc200 {
+    margin-top: -200px;
+}
+
 
 /*Rotation*/
 .rotate-180 {
@@ -87,8 +91,20 @@
     height: 5px;
 } 
 
+.h-30 {
+    height: 30px;
+}
+
 .h-90 {
     height: 90%;
+}
+
+.h-130 {
+    height: 130px;
+}
+
+.h-200 {
+    height: 200px;
 }
 
 .h-300 {
@@ -100,9 +116,18 @@
 }
 
 /*Width*/
+.w-30 {
+    width: 30px;
+}
+
 .w-300 {
     width: 300px;
 }
+
+.w-130 {
+    width: 130px;
+}
+
 .min-w-60 {
     min-width: 60px;
 }


### PR DESCRIPTION
## Description Of Changes
Some custom css has been added to support the addition of an author
card on the blog. This is mostly utility classes relating to
height/width/margins.

## Motivation and Context
We need these styles in order to show the author information correctly.

## Testing
1. Choco-theme was linked up to the blog repository and tested with the updated source changes.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/127
* https://github.com/chocolatey/blog/issues/35

Fixes #127

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
