### PR TITLE
(#131) Update CSS/JS for sticky-top

### DIFF
--- a/js/chocolatey-sticky-top.js
+++ b/js/chocolatey-sticky-top.js
@@ -4,7 +4,9 @@
     if (stickyHeader) {
         var navImage = document.querySelector('.navbar-brand-desktop'),
             logoSmall = '/assets/images/global-shared/logo.svg',
-            logoLarge = '/assets/images/global-shared/logo-square.svg';;
+            logoLarge = '/assets/images/global-shared/logo-square.svg';
+
+        document.body.classList.add('sticky-nav-active');
 
         if (document.body.scrollTop == 0 || document.documentElement.scrollTop == 0) {
             navImage.setAttribute('src', logoLarge);

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -64,10 +64,10 @@ h1, h2 {
 .sticky-top {
     max-height: 100vh;
     overflow: auto;
+}
 
-    &:not(header) {
-        top: 65px;
-    }
+.sticky-nav-active .sticky-top:not(header) {
+    top: 65px;
 }
 
 /*Scrollbars*/


### PR DESCRIPTION
## Description Of Changes
The CSS for determining the position of the sticky-top navigation
needed to be a bit smarter. If the sticky top navigation is not enabled,
then the any div with the "sticky-top" class should be positioned at
0. If the sticky top navigation is enabled however, any other div with
the class "sticky-top" should be set at 65px (height of top nav). This
allows for correct positioning of both the top nav and any additional
sticky items on the page.

## Motivation and Context
Without this, positioning of the sticky items can become jumbled or not at the top of the page where they should be.

## Testing
1. Linked choco-theme up to chocolatey.org and visited the /pricing page. Enabled the top sticky navigation. On scrolling down the second section, both the top nav and the secondary nav are stacked and sticky.

<img width="1390" alt="Screen Shot 2022-01-27 at 2 45 09 PM" src="https://user-images.githubusercontent.com/42750725/151440786-030fd265-2e4d-4342-87fb-8344e8dfe288.png">


## Change Types Made
* [x] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/131

Fixes #131

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
