### PR TITLE
(tables) Add styles to support sticky table head

### DIFF
--- a/js/chocolatey-sticky-table.js
+++ b/js/chocolatey-sticky-table.js
@@ -1,0 +1,18 @@
+(function() {
+    var scrollStickyTable = document.querySelector('.table-sticky'),
+        scrollStickyTableHeader = document.querySelector(".table-sticky-header");
+
+    if (scrollStickyTable) {
+        scrollStickyTable.addEventListener('scroll', function(e) {
+            syncScroll(scrollStickyTableHeader, scrollStickyTable);
+        });
+
+        scrollStickyTableHeader.addEventListener('scroll', function(e) {
+            syncScroll(scrollStickyTable, scrollStickyTableHeader);
+        });
+
+        function syncScroll(el1, el2) {
+            el1.scrollLeft = el2.scrollLeft;
+        }
+    }
+})();

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -100,6 +100,32 @@ h1, h2 {
     display: none;
 }
 
+.table-col-3 {
+    .table-sticky-header > div:first-child, tbody th, thead th {
+        width: 40%;
+        min-width: 200px;
+    }
+
+    .table-sticky-header > div:not(:first-child), tbody td {
+        width: 20%;
+        min-width: 100px;
+    }
+
+    .table-sticky table, .table-sticky-header {
+        width: calc(100% - 1px);
+        margin: auto;
+    }
+
+    .table-sticky-header {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
+    }
+}
+
 /*Images & Main Content*/
 img, svg {
     max-width: 100%;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -80,6 +80,9 @@
     margin-top: -200px;
 }
 
+.ms-c35 {
+    margin-left: 35px;
+}
 
 /*Rotation*/
 .rotate-180 {
@@ -150,6 +153,18 @@
 
 .min-w-300 {
     min-width: 300px;
+}
+
+.w-35 {
+    width: 35px;
+}
+
+.w-20-percent {
+    width: 20%;
+}
+
+.w-40-percent {
+    width: 40%;
 }
 
 /*Borders*/


### PR DESCRIPTION
## Description Of Changes
Creating a responsive table with a sticky header is tricky. A few
custom styles have been added to support this. A simple JS script has
also been added which will scroll the sticky header along with the body
of the table horizontally. Certain utility classes are also defined
here that can be used on tables, or wherever needed.

## Motivation and Context
Sticky tables are useful when comparing information.

## Testing
1. Linked this to the blog repository and created a testing sticky table.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
