### PR TITLE
(#138) Script Builder- Compare Package Id vs Title

### DIFF
--- a/js/chocolatey-script-builder.js
+++ b/js/chocolatey-script-builder.js
@@ -190,7 +190,7 @@
                                 storageImage = getStorage[2],
                                 storageValue = getStorage[3];
 
-                            if (storageTitle == packageTitle) {
+                            if (findScriptValue(storageValue) == findScriptValue(packageValue)) {
                                 // Show modal
                                 var modalBuilderVersionWarning = document.getElementById('Modal_ScriptBuilderVersionWarning'),
                                     modalBuilderVersionWarningInstance = Modal.getInstance(modalBuilderVersionWarning) ? Modal.getInstance(modalBuilderVersionWarning) : new Modal(modalBuilderVersionWarning, { keyboard: false, backdrop: 'static' });


### PR DESCRIPTION
## Description Of Changes
Previously, Script Builder was comparing the package Title when trying
to determine if there was already a package with the same name in a
users builder. In most cases this works, but in the case that the
package title changed, it was allowing multiple versions of the same
package and not prompting a warning to choose one.

Now, instead of comparing package Title, the package Value (Id) is
compared. This is a more reliable way of knowing if there is already a
version of the same package in a users builder since the Id of the
package will never change.

## Motivation and Context
It is unlikely that a user would want to install multiple versions of the same package. In most cases this would probably be done in error and might cause errors on install as well.

## Testing
1. Downloaded and added the appropriate packages listed in the issue onto my local running instance of the community repository. 
2. Linked up the changes in choco-theme
3. Tried added the two versions into my builder and ensured that the package warning prompt appeared.
4. Also tried on a few other random packages that I have on my local instance with multiple versions, to ensure everything works as expected.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/home/issues/102
* https://github.com/chocolatey/choco-theme/issues/138

Fixes #138

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
