### PR TITLE
(#142) Navigate to nested items on hash change

### DIFF
--- a/js/chocolatey-collapse-nested.js
+++ b/js/chocolatey-collapse-nested.js
@@ -1,8 +1,8 @@
 (function() {
     nestedCollapseLocation();
     nestedTabLocation();
-    //window.onhashchange = nestedCollapseLocation;
-    //window.onhashchange = nestedTabLocation;
+    window.onhashchange = nestedCollapseLocation;
+    window.onhashchange = nestedTabLocation;
 
     function nestedCollapseLocation() {
         if (location.hash) {


### PR DESCRIPTION
## Description Of Changes
The implementation for navigating to a hash that located inside of a
collapsed or tabbed element already existed, however it was commented
out. This removes the comments to enable this functionality.

This will mainly be used on the docs site when clicking on a right hand
navigation item that may be located inside a collapsed element.

## Motivation and Context
Links should always navigate to where they are pointing to.

## Testing
1. Linked choco-theme to both docs and community
2. On the docs site, went to `/en-us/choco/setup`
3. In the right hand nav, clicked on "Completely Offline Install" (2nd option under "More Install Options")
4. Clicking opened up the collapsed element and navigated me to the correct spot.
5. On community, I ensured all of the functionality still worked as expected on the packages page when trying to navigate to a link inside a collapsed element.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/142
* https://github.com/chocolatey/docs/issues/367

Fixes #142

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
