### PR TITLE
(#130) Update Margin/Padding Utilities

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -2,52 +2,52 @@
 @each $space, $value in $spaces {
     // Padding in rem
     .pt-c#{$space} {
-        padding-top: #{$space}rem !important;
+        padding-top: #{$value}rem !important;
     }
 
     .pe-c#{$space} {
-        padding-right: #{$space}rem !important;
+        padding-right: #{$value}rem !important;
     }
 
     .pb-c#{$space} {
-        padding-bottom: #{$space}rem !important;
+        padding-bottom: #{$value}rem !important;
     }
 
     .ps-c#{$space} {
-        padding-left: #{$space}rem !important;
+        padding-left: #{$value}rem !important;
     }
 
     // Margin in rem
     .mt-c#{$space} {
-        margin-top: #{$space}rem !important;
+        margin-top: #{$value}rem !important;
     }
 
     .me-c#{$space} {
-        margin-right: #{$space}rem !important;
+        margin-right: #{$value}rem !important;
     }
 
     .mb-c#{$space} {
-        margin-bottom: #{$space}rem !important;
+        margin-bottom: #{$value}rem !important;
     }
 
     .ms-c#{$space} {
-        margin-left: #{$space}rem !important;
+        margin-left: #{$value}rem !important;
     }
 
     .mt-cn#{$space} {
-        margin-top: -#{$space}rem !important;
+        margin-top: -#{$value}rem !important;
     }
 
     .me-cn#{$space} {
-        margin-right: -#{$space}rem !important;
+        margin-right: -#{$value}rem !important;
     }
 
     .mb-cn#{$space} {
-        margin-bottom: -#{$space}rem !important;
+        margin-bottom: -#{$value}rem !important;
     }
 
-    .ms-nc#{$space} {
-        margin-left: -#{$space}rem !important;
+    .ms-cn#{$space} {
+        margin-left: -#{$value}rem !important;
     }
 }
 


### PR DESCRIPTION
## Description Of Changes
This updates the margin and padding utilities to use the value from the
SASS map instead of the name that is used in the class title. This will
ensure values that have a decimal in them are represented appropriately.

## Motivation and Context
Currently a class that should have the value of `.75rem` gets the value of `75rem`, which is not correct (this is just an example).

## Testing
1. Linked up to the portal and up to chocolatey.org

## Change Types Made
* [x] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
#130 