### PR TITLE
(#133) Update global nav community link

### DIFF
--- a/partials/globalnavigation.txt
+++ b/partials/globalnavigation.txt
@@ -1,6 +1,6 @@
 <ul class="nav global-nav-ul fw-bold flex-wrap flex-sm-fill justify-content-sm-end overflow-hidden">
     <li class="nav-item"><a class="nav-link" href="https://chocolatey.org" target="_blank" rel="noreferrer">Main</a></li>
-    <li class="nav-item"><a class="nav-link" href="https://chocolatey.org/community" target="_blank" rel="noreferrer">Community</a></li>
+    <li class="nav-item"><a class="nav-link" href="https://community.chocolatey.org" target="_blank" rel="noreferrer">Community</a></li>
     <li class="nav-item"><a class="nav-link" href="https://docs.chocolatey.org/en-us/" target="_blank" rel="noreferrer">Docs</a></li>
     <li class="nav-item"><a class="nav-link" href="https://blog.chocolatey.org" target="_blank" rel="noreferrer">Blog</a></li>
     <li class="nav-item"><a class="nav-link" href="https://chocolatey.org/install" target="_blank" rel="noreferrer">Install</a></li>


### PR DESCRIPTION
## Description Of Changes
Updates the "Community" link in the global navigation partial to
reference community.chocolatey.org directly instead of the redirect.

## Motivation and Context
While this is a small point, redirects might as well be fixed and replaced with the real link when found.

## Testing
1. Ensured the new link inserted worked in the browser.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
#133 

Fixes #133

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.