### PR TITLE
(#151) Temporarily hard code time conversion

### DIFF
--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -113,7 +113,8 @@
         <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank">
             <img class="img-fluid mb-3" src="https://chocolatey.org/assets/images/events/04-00.jpg" alt="Chocolatey Explained - Monthly Twitch Stream" />
         </a>
-        <p class="convert-utc-to-local fw-bold" data-event-utc='06/03/2021 16:00:00' data-event-occurrence="1" data-event-include-break="true"></p>
+        @*<p class="convert-utc-to-local fw-bold" data-event-utc='06/03/2021 16:00:00' data-event-occurrence="1" data-event-include-break="true"></p>*@
+        <p>First Thursday of Every Month<br>5:00 PM UTC</p>
         <p class="text-start">Join us on the first Thursday of every month for "Chocolatey Explained" where we will cover different Chocolatey topics in detail.</p>
         <a href="https://www.twitch.tv/chocolateysoftware" class="btn bg-twitch text-white btn-width mt-2" target="_blank" rel="nofollow"><i class="fab fa-twitch"></i> Follow on Twitch</a>
         <hr />


### PR DESCRIPTION
## Description Of Changes
In an effort to quickly update the time on the websites to be correct,
the time has temporarily been hardcoded to not use Luxon for
conversions.

Right now, only one place is effected in choco-theme, located on the Twitch stream announcement in the right side flyout.

## Motivation and Context
We want to display the correct time as to not cause confusion, especially because we have a Twitch stream tomorrow (March 3, 2022).

## Testing
1. Linked choco-theme to my local chocolatey.org and ran
2. Ensured the time on the right side flyout was hardcoded correctly to 5PM UTC.

## Change Types Made
* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/chocolatey.org/issues/122
* https://github.com/chocolatey/home/issues/139
* https://github.com/chocolatey/choco-theme/issues/151

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

