### PR TITLE
(#151) Ensure Luxon Date Conversions are Correct

### DIFF
--- a/js/chocolatey-functions.js
+++ b/js/chocolatey-functions.js
@@ -60,16 +60,13 @@
     convertEventTimeToLocal.forEach(function (el) {
         var timeIncludeBreak = el.getAttribute('data-event-include-break'),
             timeOccurrence = el.getAttribute('data-event-occurrence'),
-            utcTime = el.getAttribute('data-event-utc').split(' '),
-            datePart = utcTime[0].split('/'),
-            timePart = utcTime[1].split(':'),
-            utcDateTime = luxon.DateTime.utc(parseInt(datePart[2]), parseInt(datePart[0]), parseInt(datePart[1]), parseInt(timePart[0]), parseInt(timePart[1]), parseInt(timePart[2])),
+            definedDate = luxon.DateTime.fromISO(el.getAttribute('data-event-utc')),
             timeIncludeBreakText,
             timeOccurrenceText;
 
         if (timeIncludeBreak == 'true') {
             timeIncludeBreakText = '<br />';
-        } else if (timeOccurrence == "-2" && utcDateTime.toISO() <= luxon.DateTime.utc().toISO()) {
+        } else if (timeOccurrence == "-2" && definedDate <= luxon.DateTime.utc().toISO()) {
             timeIncludeBreakText = ' '
         } else {
             timeIncludeBreakText = 'at ';
@@ -77,31 +74,31 @@
 
         switch (timeOccurrence) {
             case "0":
-                timeOccurrenceText = 'Every ' + utcDateTime.toLocal().toFormat('cccc') + ' ' + timeIncludeBreakText;
+                timeOccurrenceText = 'Every ' + definedDate.toLocal().toFormat('cccc') + ' ' + timeIncludeBreakText;
                 break;
             case "1":
-                timeOccurrenceText = 'First ' + utcDateTime.toLocal().toFormat('cccc') +  ' of Every Month ' + timeIncludeBreakText;
+                timeOccurrenceText = 'First ' + definedDate.toLocal().toFormat('cccc') +  ' of Every Month ' + timeIncludeBreakText;
                 break;
             case "-1":
-                timeOccurrenceText = utcDateTime.toLocal().toFormat('cccc, dd LLL yyyy') + timeIncludeBreakText;
+                timeOccurrenceText = definedDate.toLocal().toFormat('cccc, dd LLL yyyy') + timeIncludeBreakText;
                 break;
             case "-2":
-                timeOccurrenceText = utcDateTime.toLocal().toFormat('cccc, dd LLL yyyy') + ' ' + timeIncludeBreakText;
+                timeOccurrenceText = definedDate.toLocal().toFormat('cccc, dd LLL yyyy') + ' ' + timeIncludeBreakText;
                 break;
             default:
                 timeOccurrenceText = '';
         }
 
         if (timeOccurrence) {
-            if (timeOccurrence == "-2" && utcDateTime.toISO() <= luxon.DateTime.utc().toISO()) {
-                el.innerHTML = 'Webinar Replay from' + timeIncludeBreakText +  utcDateTime.toLocal().toFormat('cccc, dd LLL yyyy');
+            if (timeOccurrence == "-2" && definedDate <= luxon.DateTime.utc().toISO()) {
+                el.innerHTML = 'Webinar Replay from' + timeIncludeBreakText +  definedDate.toLocal().toFormat('cccc, dd LLL yyyy');
             } else {
-                el.innerHTML = timeOccurrenceText + utcDateTime.toLocal().toFormat("h:mm a ZZZZ") + ' / ' + utcDateTime.toFormat("h:mm a 'GMT'");
+                el.innerHTML = timeOccurrenceText + definedDate.toLocal().toFormat("h:mm a ZZZZ") + ' / ' + definedDate.toUTC().toFormat("h:mm a ZZZZ");
             }
             return;
         }
 
-        el.innerHTML = utcDateTime.toLocal().toFormat("cccc, dd LLL yyyy ") + timeIncludeBreakText + utcDateTime.toLocal().toFormat("h:mm a ZZZZ") + ' / ' + utcDateTime.toFormat("h:mm a 'GMT'");
+        el.innerHTML = definedDate.toLocal().toFormat("cccc, dd LLL yyyy ") + timeIncludeBreakText + definedDate.toLocal().toFormat("h:mm a ZZZZ") + ' / ' + definedDate.toUTC().toFormat("h:mm a ZZZZ");
     });
 
     window.copyCodeBlocks=function() {

--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -113,8 +113,7 @@
         <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank">
             <img class="img-fluid mb-3" src="https://chocolatey.org/assets/images/events/04-00.jpg" alt="Chocolatey Explained - Monthly Twitch Stream" />
         </a>
-        @*<p class="convert-utc-to-local fw-bold" data-event-utc='06/03/2021 16:00:00' data-event-occurrence="1" data-event-include-break="true"></p>*@
-        <p>First Thursday of Every Month<br>5:00 PM UTC</p>
+        <p class="convert-utc-to-local fw-bold" data-event-utc='2022-03-03T17:00:00Z' data-event-occurrence="1" data-event-include-break="true"></p>
         <p class="text-start">Join us on the first Thursday of every month for "Chocolatey Explained" where we will cover different Chocolatey topics in detail.</p>
         <a href="https://www.twitch.tv/chocolateysoftware" class="btn bg-twitch text-white btn-width mt-2" target="_blank" rel="nofollow"><i class="fab fa-twitch"></i> Follow on Twitch</a>
         <hr />


### PR DESCRIPTION
## Description Of Changes
To ensure that dates converted by Luxon are correct, changes to the
initial input string were made along with some refactoring of the JS
that controls the conversions.

The default string that is captured from the html has been updated from:
07/29/2020 03:30:00

To:
2020-07-29T03:30:00Z

Updating the string ensures that conversions will be done correctly
between time zones and will accurately take into account and offsets due
to daylight savings time.

## Testing
1. Linked choco-theme to my local chocolatey.org and ran
2. Ensured the times were being converted correctly on the chocolatey.org home page for the Twitch stream announcement, in the right side flyout for the Twitch stream announcement, and on the Events home page.
3. Changed the date of an event that was already expired to a date in the future. Doing this correctly showed the time on the countdown timers, the date conversions on the event listing, and showed the event in the "Upcoming" section on the Event home page.


## Change Types Made
* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/chocolatey.org/issues/122
* https://github.com/chocolatey/home/issues/139
* https://github.com/chocolatey/choco-theme/issues/151

Fixes #151 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

