### PR TITLE
(#142) Navigate to nested items on hash change

### DIFF
--- a/js/chocolatey-collapse-nested.js
+++ b/js/chocolatey-collapse-nested.js
@@ -1,13 +1,13 @@
 (function() {
     nestedCollapseLocation();
     nestedTabLocation();
-    window.onhashchange = nestedCollapseLocation;
-    window.onhashchange = nestedTabLocation;
+    window.addEventListener('hashchange', nestedCollapseLocation, false);
+    window.addEventListener('hashchange', nestedTabLocation, false);
 
     function nestedCollapseLocation() {
         if (location.hash) {
             var el = document.querySelector(escapeId(location.hash));
-            
+
             if (el) {
                 var elScroll = el,
                     collapseParents = getParents(el).filter(el => el != document && el.classList.contains('collapse'));


### PR DESCRIPTION
## Description Of Changes
This updates how anchors are navigated to when they are located
inside a collapsed element. The previous implementation stopped working,
and this is a long term solution to fix the bug for good. This is
mostly used on the docs site on the setup Chocolatey Cli page, and on
the pricing page, however it can be used anywhere needed.

## Motivation and Context
This feature was working, but stopped randomly at some point. This fix here will ensure it will be fixed long term.

## Testing
1. Linked choco-theme to chocolatey.org and ensured the anchor links on the pricing page worked.
2. Linked to doc locally and ensured the links inside the collapsed "Install Options" were navigatable.

## Change Types Made
* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/142
* https://github.com/chocolatey/docs/issues/367
* https://github.com/chocolatey/chocolatey.org/issues/126

Fixes #142

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
