### PR TITLE
(maint) Update time on reoccuring Twitch stream

### DIFF
--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -171,7 +171,7 @@
         <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank">
             <img class="border mb-3" src="https://chocolatey.org/assets/images/events/04-00.jpg" alt="Chocolatey Explained - Monthly Twitch Stream" />
         </a>
-        <p class="convert-utc-to-local fw-bold" data-event-utc='2022-03-03T17:00:00Z' data-event-occurrence="1" data-event-include-break="true"></p>
+        <p class="convert-utc-to-local fw-bold" data-event-utc='2022-04-07T17:00:00Z' data-event-occurrence="1" data-event-include-break="true"></p>
         <p class="text-start">Join us on the first Thursday of every month for "Chocolatey Explained" where we will cover different Chocolatey topics in detail.</p>
         <a href="https://www.twitch.tv/chocolateysoftware" class="btn btn-twitch btn-width mt-2" target="_blank" rel="nofollow"><i class="fab fa-twitch"></i> Follow on Twitch</a>
         <hr />


### PR DESCRIPTION
## Description Of Changes
This updates the time on the reoccurring Twitch stream event. Because of
the JS, and timezones, this needed to be reset to the next upcoming
stream.

## Motivation and Context
The time on this is showing incorrectly since we have switched to Daylight Savings Time.

## Testing
1. Linked to chocolatey.org and ensured the time showed correctly.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
n/a - Quick maintenance update

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
