### PR TITLE
Prevent Button Text Change in Flyout

### DIFF
--- a/js/chocolatey-countdown.js
+++ b/js/chocolatey-countdown.js
@@ -113,7 +113,7 @@
 
     function replaceElapsed() {
         jQuery('.countdown-details').add(countdownContainer).add(jQuery('.countdown-date')).add(jQuery('.btn-not-on-demand')).add(jQuery('.btn-add-to-calendar')).remove();
-        jQuery('a, h3').each(function () {
+        jQuery('a:not(.btn-sidebar), h3').each(function () {
             jQuery(this).html(jQuery(this).html()
                 .replace('Reserve My Spot Now', ellapsedButtonText)
                 .replace('Register Now', ellapsedButtonText)

--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -68,7 +68,7 @@
             }
             </div>
         </div>
-        <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank" class="btn btn-primary mt-2 mx-1">Register Now</a>
+        <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank" class="btn btn-primary btn-sidebar mt-2 mx-1">Register Now</a>
     </div>
 </div>
 <hr />


### PR DESCRIPTION
## Description Of Changes
When an event is over, the button text is changed by JS automatically.
In the sidebar, this is not ideal, or hasn't been considered yet in the
JS, and was happening inaccurately. If on a an event page that was
expired, every button in the right flyout would say "Watch On-Demand"
even if the event hadn't happened yet. This update changes the buttons
in the flyout to be more specific, that way they can be excluded in the
JS.

## Motivation and Context
While a small detail, we want button text to be accurate and not confusing.

## Testing
1. Linked choco-theme to chocolatey.org and ensured button text did not change.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
n/a- maintenance 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
