### PR TITLE
Update Intune Webinar After Event

### DIFF
--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -37,42 +37,6 @@
 </div>
 <hr />
 <div class="text-center">
-    <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank">
-        <img class="border mb-3" src="https://chocolatey.org/assets/images/events/01-11.jpg" alt="Chocolatey and Intune Overview" />
-    </a>
-    <p class="convert-utc-to-local fw-bold" data-event-utc="2022-03-30T15:00:00Z" data-event-occurrence="-1" data-event-include-break="true"></p>
-    <p class="text-start">At Chocolatey Software we strive for simple, and teaching others. Please join us so we can teach you just how simple it could be to keep your 3rd party applications updated across your devices, all with Intune!</p>
-    <div class="d-flex align-items-center justify-content-center flex-wrap">
-        <a href="https://chocolatey.org/events/chocolatey-and-intune-overview" class="btn btn-outline-primary mt-2 mx-1">Learn More</a>
-        <div class="mt-2 mx-1">
-            <div class="atcb" style="display:none;">
-            {
-                "name":"Chocolatey and Intune Overview",
-                "description":"At Chocolatey Software we strive for simple, and teaching others. Please join us so we can teach you just how simple it could be to keep your 3rd party applications updated across your devices, all with Intune!",
-                "location":"https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw",
-                "startDate":"2022-03-30",
-                "endDate":"2022-03-30",
-                "startTime":"15:00",
-                "endTime":"16:00",
-                "options":[
-                    "Apple",
-                    "Google",
-                    "iCal",
-                    "Microsoft365",
-                    "Outlook.com",
-                    "Yahoo"
-                ],
-                "trigger":"click",
-                "inline":true,
-                "iCalFileName":"chocolatey-and-intune-overview"
-            }
-            </div>
-        </div>
-        <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank" class="btn btn-primary btn-sidebar mt-2 mx-1">Register Now</a>
-    </div>
-</div>
-<hr />
-<div class="text-center">
     <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank">
         <img class="border mb-3" src="https://chocolatey.org/assets/images/events/01-12.jpg" alt="Find It, Add It, Install It with Script Builder" />
     </a>
@@ -104,6 +68,18 @@
             </div>
         </div>
         <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank" class="btn btn-twitch mt-2 mx-1"><i class="fab fa-twitch"></i> Follow on Twitch</a>
+    </div>
+</div>
+<hr />
+<div class="text-center">
+    <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank">
+        <img class="border mb-3" src="https://chocolatey.org/assets/images/events/01-11.jpg" alt="Chocolatey and Intune Overview" />
+    </a>
+    <p><strong>Webinar Replay from<br />Wednesday, 30 March 2022</strong></p>
+    <p class="text-start">At Chocolatey Software we strive for simple, and teaching others. Let us teach you just how simple it could be to keep your 3rd party applications updated across your devices, all with Intune!</p>
+    <div class="d-flex align-items-center justify-content-center flex-wrap">
+        <a href="https://chocolatey.org/events/chocolatey-and-intune-overview" class="btn btn-outline-primary mt-2 mx-1">Learn More</a>
+        <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank" class="btn btn-primary btn-sidebar mt-2 mx-1">Watch On-Demand</a>
     </div>
 </div>
 <hr />


### PR DESCRIPTION
## Description Of Changes
This updates the right side flyout so that the Intune Webinar shows as
a replay instead of an upcoming event. The Add To Calendar button
has been removed. This is still pinned to the top of the flyout, but it
is now under the upcoming Script Builder Twitch stream.

## Motivation and Context
We do not want events in the flyout with inaccurate information.

## Testing
1. Linked choco-theme locally to chocolatey.org and ran.
2. Ensured everything in the flyout was correct

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
[ENGTASKS-670](https://app.clickup.com/t/20540031/ENGTASKS-670l)

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
