### PR TITLE
Update Table Style from Bootstrap Upgrade

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -90,6 +90,10 @@ h1, h2 {
     thead:not(.text-wrap) {
         white-space: nowrap!important;
     }
+
+    > :not(:first-child) {
+        border-top: 2px solid var(--border);
+    }
 }
 
 .table-dark {


### PR DESCRIPTION
## Description Of Changes
With the upgrade to Bootstrap 5.1, an additional table style was added
that was not yet part of choco-theme. This modifies the specific style
to make it fit into our theme better.

## Motivation and Context
Without this change, the tables looked "off". Now, they fit into choco-theme. Most people won't even notice anything changed.

## Testing
1. Linked to all repositories that use choco-theme locally
2. On the docs repository, went to `en-us/chocolatey-gui/release-notes` and inspected the tables to ensure they looks correct.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* [ENGTASKS-1339](https://app.clickup.com/t/20540031/ENGTASKS-1339)
* https://github.com/chocolatey/choco-theme/issues/166
* https://github.com/chocolatey/chocolatey.org/issues/139
* https://github.com/chocolatey/blog/issues/146
* https://github.com/chocolatey/home/issues/152
* https://github.com/chocolatey/docs/issues/429

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
