### PR TITLE
Add lite-youtube-embed JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jquery-validation": "^1.19.3",
     "jquery-validation-unobtrusive": "^3.2.11",
     "knockout": "^3.5.1",
+    "lite-youtube-embed": "^0.2.0",
     "luxon": "^2.0.2",
     "marked": "^4.0.10",
     "merge-stream": "^2.0.0",


### PR DESCRIPTION
## Description Of Changes
This library helps with lazy loading of YouTube videos so that pages
with lots of videos on them don't get loaded until they are click on to
be played. This is slightly better than just lazy loading the video on
scroll, as nothing but a placeholder image will display that looks like
a video until it is actually really do be watched.

## Motivation and Context
This can speed up the Google Lighthouse results by up to 10 points.

## Testing
1. Ran the Google Lighthouse tool on chocolateyfest.com and got an 83 on performance.
2. After implementing this, I received a 95. The page also feels more snappy.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/chocolateyfest/issues/3

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
