### PR TITLE
(#180)(#181) Remove Birthday Bits and Update HTML Encoding

### DIFF
--- a/partials/AlertText.txt
+++ b/partials/AlertText.txt
@@ -1,1 +1,0 @@
-Happy Birthday to Chocolatey! As we turn 11 this month we wanted to <a class='fw-bold link-light' href='https://blog.chocolatey.org/2022/03/announcing-11-years-of-chocolatey/'><u> make an epic announcement</u></a>!

--- a/partials/TermsContent.html
+++ b/partials/TermsContent.html
@@ -148,7 +148,7 @@
         Attempt to impersonate another user or person or use the username of another user.
     </li>
     <li>
-        Upload or transmit (or attempt to upload or to transmit) any material that acts as a passive or active information collection or transmission mechanism, including without limitation, clear graphics interchange formats ("gifs"), 1×1 pixels, web bugs, cookies, or other similar devices (sometimes referred to as "spyware" or "passive collection mechanisms" or "pcms").
+        Upload or transmit (or attempt to upload or to transmit) any material that acts as a passive or active information collection or transmission mechanism, including without limitation, clear graphics interchange formats ("gifs"), 1&#xD7;1 pixels, web bugs, cookies, or other similar devices (sometimes referred to as "spyware" or "passive collection mechanisms" or "pcms").
     </li>
     <li>
         Interfere with, disrupt, or create an undue burden on the Site or the networks or services connected to the Site.

--- a/partials/TopAlertBanner.txt
+++ b/partials/TopAlertBanner.txt
@@ -4,15 +4,11 @@
 
     if (!string.IsNullOrEmpty(topNoticeText))
     {
-        <div id="topNoticeAlert" class="alert bg-purple alert-dismissible alert-dismissible-center fade show d-none p-0 justify-content-between" role="alert">
-            <img class="d-none d-md-block" src="https://blog.chocolatey.org/assets/images/corner-party-garland-start.svg" style="height:85px" />
-            <div class="d-flex align-items-center justify-content-center px-3">
-                <p class="mb-0 text-white py-3 py-md-0 pe-3 pe-md-0">@Html.Raw(topNoticeText)</p>
-            </div>
+        <div id="topNoticeAlert" class="alert alert-success alert-dismissible alert-dismissible-center fade show d-none" role="alert">
+            <p class="mb-0">@Html.Raw(topNoticeText)</p>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
                 <i class="fas fa-times" aria-hidden="true"></i>
             </button>
-            <img class="d-none d-md-block" src="https://blog.chocolatey.org/assets/images/corner-party-garland-end.svg" style="height:85px" />
         </div>
     }
 }


### PR DESCRIPTION
## Description Of Changes
* Removes the Chocolatey Birthday top alert banner
* Updates HTML encoding of the `x` character so it displays correctly

## Motivation and Context
Chocolatey's birthday month is over, so there is no need for the banner anymore. 

## Testing
1. Linked choco-theme up to each repository locally
2. Ensured the birthday banner no longer showed up
3. For the HTML encoding issue, I ensured the `x` symbol appeared how it should on each repository.

## Change Types Made
* [x] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/180
* https://github.com/chocolatey/choco-theme/issues/181
* https://github.com/chocolatey/chocolatey.org/issues/149
* https://github.com/chocolatey/docs/issues/460
* https://github.com/chocolatey/blog/issues/158
* https://github.com/chocolatey/home/issues/154
* [ENGTASKS-1207](https://app.clickup.com/t/20540031/ENGTASKS-1207)

Fixes #180 
Fixes #181

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
