### PR TITLE
(#184) Add Hover Text to Social Icons

### DIFF
--- a/partials/socialmedia.txt
+++ b/partials/socialmedia.txt
@@ -1,55 +1,55 @@
 <ul class="list-unstyled list-inline mb-0">
     <li class="list-inline-item">
-        <a href="https://twitter.com/chocolateynuget" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Twitter">
+        <a href="https://twitter.com/chocolateynuget" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Twitter" title="Connect with Chocolatey on Twitter">
             <div class="bg-twitter circle" aria-hidden="true">
                 <i class="fab fa-twitter"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://www.linkedin.com/company/chocolatey-software/" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on LinkedIn">
+        <a href="https://www.linkedin.com/company/chocolatey-software/" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on LinkedIn" title="Connect with Chocolatey on LinkedIn">
             <div class="bg-linkedin circle" aria-hidden="true">
                 <i class="fab fa-linkedin-in"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://github.com/chocolatey" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on GitHub">
+        <a href="https://github.com/chocolatey" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on GitHub" title="Connect with Chocolatey on GitHub">
             <div class="bg-github circle" aria-hidden="true">
                 <i class="fab fa-github"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://www.youtube.com/chocolateysoftware" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on YouTube">
+        <a href="https://www.youtube.com/chocolateysoftware" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on YouTube" title="Connect with Chocolatey on YouTube">
             <div class="bg-youtube circle" aria-hidden="true">
                 <i class="fab fa-youtube"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://www.twitch.tv/chocolateysoftware" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Twitch">
+        <a href="https://www.twitch.tv/chocolateysoftware" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Twitch" title="Connect with Chocolatey on Twitch">
             <div class="bg-twitch circle" aria-hidden="true">
                 <i class="fab fa-twitch"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://facebook.com/ChocolateySoftware" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Facebook">
+        <a href="https://facebook.com/ChocolateySoftware" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Facebook" title="Connect with Chocolatey on Facebook">
             <div class="bg-facebook circle" aria-hidden="true">
                 <i class="fab fa-facebook-f"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://ch0.co/community" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Community Chat">
+        <a href="https://ch0.co/community" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Community Chat" title="Connect with Chocolatey on Community Chat">
             <div class="bg-chat circle" aria-hidden="true">
                 <i class="far fa-comment"></i>
             </div>
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://groups.google.com/forum/#!forum/chocolatey" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Google Groups">
+        <a href="https://groups.google.com/forum/#!forum/chocolatey" target="_blank" rel="noreferrer" aria-label="Connect with Chocolatey on Google Groups" title="Connect with Chocolatey on Google Groups">
             <div class="bg-google circle" aria-hidden="true">
                 <i class="fab fa-google"></i>
             </div>


### PR DESCRIPTION
## Description Of Changes
This adds hover text on Social Media icons found in the footer in most
places, and the "Stay Connected" area on the blog. 

## Motivation and Context
This improves accessibility so users can easily identify what these icons are for
without clicking them.

## Testing
1. Linked locally to chocolatey.org, blog, and community
2. Hovered over the icons to ensure the tooltips showed

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* https://github.com/chocolatey/home/issues/147
* https://github.com/chocolatey/blog/issues/162
* https://github.com/chocolatey/choco-theme/issues/184
* https://github.com/chocolatey/chocolatey.org/issues/152

Fixes #184

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
