### PR TITLE
Update Wording in Right Side Flyout

### DIFF
--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -36,41 +36,6 @@
     </div>
 </div>
 <hr />
-<div class="text-center">
-    <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank">
-        <img class="border mb-3" src="https://chocolatey.org/assets/images/events/01-15.jpg" alt="Chocolatey Community Coffee Break" />
-    </a>
-    <p class="convert-utc-to-local fw-bold" data-event-utc="2022-05-05T16:00:00Z" data-event-occurrence="-1" data-event-include-break="true"></p>
-    <p class="text-start">The Chocolatey Community is close to the hearts of many of the Chocolatey Team. If you want to find out more about it, what we do and how you can get involved then come along to our next live stream and join Gary, Kim and Paul.</p>
-    <div class="d-flex align-items-center justify-content-center flex-wrap">
-        <div class="mt-2 mx-1">
-            <div class="atcb atcb-twitch" style="display:none;">
-            {
-                "name":"Chocolatey Community Coffee Break",
-                "description":"The Chocolatey Community is close to the hearts of many of the Chocolatey Team. If you want to find out more about it, what we do and how you can get involved then come along to our next live stream and join Gary, Kim and Paul.",
-                "location":"https://www.twitch.tv/chocolateysoftware",
-                "startDate":"2022-05-05",
-                "endDate":"2022-05-05",
-                "startTime":"16:00",
-                "endTime":"17:00",
-                "options":[
-                    "Apple",
-                    "Google",
-                    "iCal",
-                    "Microsoft365",
-                    "Outlook.com",
-                    "Yahoo"
-                ],
-                "trigger":"click",
-                "inline":true,
-                "iCalFileName":"twitch-azure"
-            }
-            </div>
-        </div>
-        <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank" class="btn btn-twitch mt-2 mx-1"><i class="fab fa-twitch"></i> Follow on Twitch</a>
-    </div>
-</div>
-<hr />
 <div class="shuffle">
     <div class="text-center">
         <a href="https://chocolatey.zoom.us/webinar/register/WN_3llbuDHORCuexvvR0d8naA" rel="noreferrer" target="_blank">
@@ -155,7 +120,7 @@
         <p><strong>Twitch Stream from<br />Thursday, 7 April 2022</strong></p>
         <p class="text-start">Script Builder allows you to bulk install Chocolatey packages in just a few clicks. Just add packages to Script Builder and choose your integration method to get started!</p>
         <div class="d-flex align-items-center justify-content-center flex-wrap">
-            <a href="https://chocolatey.org/events/find-it-add-it-install-it-with-script-builder" class="btn btn-outline-twitch mt-2 mx-1">Learn More</a>
+            <a href="https://chocolatey.org/events/find-it-add-it-install-it-with-script-builder" class="btn btn-outline-twitch mt-2 mx-1">Watch On-Demand</a>
             <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank" class="btn btn-twitch mt-2 mx-1"><i class="fab fa-twitch"></i> Follow on Twitch</a>
         </div>
         <hr />
@@ -169,6 +134,18 @@
         <div class="d-flex align-items-center justify-content-center flex-wrap">
             <a href="https://chocolatey.org/events/chocolatey-and-intune-overview" class="btn btn-outline-primary mt-2 mx-1">Learn More</a>
             <a href="https://chocolatey.zoom.us/webinar/register/3616467726065/WN_JHQYiUcMTTShJ_F_cDqPPw" rel="noreferrer" target="_blank" class="btn btn-primary btn-sidebar mt-2 mx-1">Watch On-Demand</a>
+        </div>
+        <hr />
+    </div>
+    <div class="text-center">
+        <a href="https://chocolatey.org/events/chocolatey-community-coffee-break" rel="noreferrer" target="_blank">
+            <img class="border mb-3" src="https://chocolatey.org/assets/images/events/01-15.jpg" alt="Chocolatey Community Coffee Break" />
+        </a>
+        <p><strong>Twitch Stream from<br />Thursday, 5 May 2022</strong></p>
+        <p class="text-start">The Chocolatey Community is close to the hearts of many of the Chocolatey Team. Join Gary, Kim, and Paul if you want to find out more about it, what we do, and how you can get involved.</p>
+        <div class="d-flex align-items-center justify-content-center flex-wrap">
+            <a href="https://chocolatey.org/events/chocolatey-community-coffee-break" class="btn btn-outline-twitch mt-2 mx-1">Learn More</a>
+            <a href="https://www.twitch.tv/chocolateysoftware" rel="noreferrer" target="_blank" class="btn btn-twitch mt-2 mx-1"><i class="fab fa-twitch"></i> Follow on Twitch</a>
         </div>
         <hr />
     </div>


### PR DESCRIPTION
## Description Of Changes
Since the Chocolatey Community Coffee Break Twitch stream is over, it
has been removed from the "pinned" section in the right side flyout.
The Add to Calendar buttons have also been removed.

## Motivation and Context
The stream is over and we want current information on the website.

## Testing
1. Linked choco-theme to community and chocolatey.org locally
2. Ensured the links all worked in the right side flyout and that all Add to Calendar buttons have been removed.

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
[ENGTASKS-1363](https://app.clickup.com/t/20540031/ENGTASKS-1363)

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
