### PR TITLE
(maint) Temp use jQuery for package filtering

### DIFF
--- a/js/chocolatey-packages.js
+++ b/js/chocolatey-packages.js
@@ -97,7 +97,7 @@
     });
 
     // Package Filtering
-    var packageFilters = document.querySelectorAll('.package-filter'),
+    /*var packageFilters = document.querySelectorAll('.package-filter'),
         packageSearchTerms = document.querySelectorAll('.selected-search-term');
 
     if (packageFilters) {
@@ -114,7 +114,11 @@
 
     function submitPackageFilterForm(filter) {
         filter.closest('form').submit();
-    }
+    }*/
+
+    jQuery("#sortOrder,#prerelease,#moderatorQueue,#moderationStatus,.selected-search-term").change(function () {
+        jQuery(this).closest("form").submit();
+    });
     
     // Prism for Description section
     var descriptionCode = document.querySelectorAll('#description pre');


### PR DESCRIPTION
## Description Of Changes
With the update to not use jQuery for certain functions, the package
filtering broke. For now, we are reverting back to the jQuery fix
until a non jQuery solution can be put in place.

## Motivation and Context
We want to get package filtering up and running for now.

## Testing
1. Linked choco-theme to CCR and ran locally

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
n/a

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
