### PR TITLE
(maint) Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/chocolatey/choco-theme.git"
   },
   "author": "chocolatey",
-  "license": "Apache-2.0",
+  "license": "Apache License 2.0",
   "bugs": {
     "url": "https://github.com/chocolatey/choco-theme/issues"
   },


### PR DESCRIPTION
This line was recently changed to a valid license name, however now
it is making the builds fail. An issue will be raised around this as
follow up.