### PR TITLE
(#251) Get Release Action Working

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Publish Package to npmjs
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,7 +13,7 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
           # Defaults to the user or organization that owns the workflow file
-          scope: '@chocolatey'
+          scope: '@chocolatey-software'
       - run: yarn
       - run: yarn publish --access public
         env:


### PR DESCRIPTION
## Description Of Changes
Previously, the GitHub Action for publishing to NPM/Yarn did not trigger on the created release. The event type has been changed to `published` instead. The `scope` has also been updated to the Chocolatey user account name on NPM.

## Motivation and Context
We want this action to be triggered on release.

## Testing
1. There's really not an easy way to test this, since a release needs to be created.

## Change Types Made
* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* ENGTASKS-1963
* #250 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
