### PR TITLE
(#259) Add reusable function to truncate results

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "^0.1.3"
+    "choco-theme": "^0.1.4"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/js/chocolatey-packages.js
+++ b/js/chocolatey-packages.js
@@ -1,7 +1,7 @@
 import jQuery from 'jquery';
 import EasyMDE from 'easymde';
 import { Collapse, Modal } from 'bootstrap';
-import { getCookie, setCookieExpirationNever } from './util/chocolatey-functions';
+import { getCookie, setCookieExpirationNever, truncateResults } from './util/chocolatey-functions';
 
 (() => {
     // Community Disclaimer
@@ -373,4 +373,7 @@ import { getCookie, setCookieExpirationNever } from './util/chocolatey-functions
             }
         });
     }
+
+    // Show or hide truncated version history table results on click
+    truncateResults(document.querySelector('#versionTableTruncateResults'));
 })();

--- a/js/util/chocolatey-functions.js
+++ b/js/util/chocolatey-functions.js
@@ -167,3 +167,20 @@ deploymentMethods.forEach(el => {
 if (deploymentMethodHashArray.includes(deploymentMethodHash)) {
     document.cookie = `deployment_method=${deploymentMethodHash}; path=/`;
 }
+
+// Show more or hide truncated results on click
+export const truncateResults = btnId => {
+    if (btnId) {
+        btnId.addEventListener('click', () => {
+            const results = document.querySelectorAll('tr.truncate-results');
+
+            for (const i of results) {
+                if (i.classList.contains('d-none')) {
+                    i.classList.remove('d-none');
+                } else {
+                    i.classList.add('d-none');
+                }
+            }
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description Of Changes
In the packages area, there is a table with several results that should be truncated if the results are over a certain number. A new function has been added that can be referenced for instances like this by adding the class 'truncate-results` to the rows that are intended to be truncated.

The ID of the button should be passed into the function for the click handler to be attached.

## Motivation and Context
This functionality existed in an 'onclick' handler on the Version Table on the packages page. With the recent changes to ES6 in choco-theme, this no longer worked because it did not have access to jQuery as it was referencing. Instead of making a specific function just for this, a reusable function was made so that it can be used in future cases as well. 

## Testing
1. Linked to community.chocolatey.org and tested on the Version History table.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
#259 

Fixes #259

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
