### PR TITLE
(#261) Ensure proper indention of Script Builder Scripts

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "^0.1.4"
+    "choco-theme": "^0.1.5"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/js/chocolatey-script-builder.js
+++ b/js/chocolatey-script-builder.js
@@ -1,5 +1,5 @@
 import { Collapse, Modal, Tab } from 'bootstrap';
-import { copyCodeBlocks, getCookie, selectDeploymentMethodTab } from './util/chocolatey-functions';
+import { copyCodeBlocks, getCookie, removeLineBreaks, selectDeploymentMethodTab } from './util/chocolatey-functions';
 
 (() => {
     const packages = localStorage.packageList === undefined ? new Array() : JSON.parse(localStorage.packageList); // eslint-disable-line
@@ -363,17 +363,17 @@ import { copyCodeBlocks, getCookie, selectDeploymentMethodTab } from './util/cho
                     const storageValue = findScriptValue(getStorage[3]);
                     const storagePre = findScriptPre(getStorage[3]) ? 'allow_prerelease: yes' : '';
 
-                    commandAnsible.innerHTML += `- name: Install ${storageValue}
-                      win_chocolatey:
-                        name: ${storageValue}
-                        version: ${storageVersion}
-                        source: ${internalRepoUrl}
-                        state: present
-                        ${storagePre}
-                      
-                    `;
+                    commandAnsible.innerHTML += `
+- name: Install ${storageValue}
+  win_chocolatey:
+    name: ${storageValue}
+    version: '${storageVersion}'
+    source: ${internalRepoUrl}
+    state: present
+    ${storagePre}`;
                 }
 
+                commandAnsible.innerHTML = removeLineBreaks(commandAnsible.innerHTML);
                 highlightScript(commandAnsible, 'language-yaml');
 
                 break;
@@ -384,16 +384,16 @@ import { copyCodeBlocks, getCookie, selectDeploymentMethodTab } from './util/cho
                     const storageValue = findScriptValue(getStorage[3]);
                     const storagePre = findScriptPre(getStorage[3]) ? "options  '--prerelease'" : ''; // eslint-disable-line
 
-                    commandChef.innerHTML += `chocolatey_package ${storageValue}
-                      action   :install
-                      source   '${internalRepoUrl}'
-                      version  '${storageVersion}'
-                      ${storagePre}
-                    end
-                        
-                    `;
+                    commandChef.innerHTML += `
+chocolatey_package '${storageValue}' do
+  action   :install
+  source   '${internalRepoUrl}'
+  version  '${storageVersion}'
+  ${storagePre}
+end`;
                 }
 
+                commandChef.innerHTML = removeLineBreaks(commandChef.innerHTML);
                 highlightScript(commandChef, 'language-ruby');
 
                 break;
@@ -405,17 +405,17 @@ import { copyCodeBlocks, getCookie, selectDeploymentMethodTab } from './util/cho
                     const storagePre = findScriptPre(getStorage[3]) ? 'chocoParams = "--prerelease"' : '';
                     const storageSpace = findScriptPre(getStorage[3]) ? '    ' : '';
 
-                    commandPSDSC.innerHTML += `cChocoPackageInstaller ${storageValue}
-                    {
-                        Name    ${storageSpace} = "${storageValue}"
-                        Version ${storageSpace} = "${storageVersion}"
-                        Source  ${storageSpace} = "${internalRepoUrl}"
-                        ${storagePre}
-                    }
-                        
-                    `;
+                    commandPSDSC.innerHTML += `
+cChocoPackageInstaller ${storageValue}
+{
+   Name    ${storageSpace} = "${storageValue}"
+   Version ${storageSpace} = "${storageVersion}"
+   Source  ${storageSpace} = "${internalRepoUrl}"
+   ${storagePre}
+}`;
                 }
 
+                commandPSDSC.innerHTML = removeLineBreaks(commandPSDSC.innerHTML);
                 highlightScript(commandPSDSC, 'language-powershell');
 
                 break;
@@ -427,59 +427,59 @@ import { copyCodeBlocks, getCookie, selectDeploymentMethodTab } from './util/cho
                     const storagePre = findScriptPre(getStorage[3]) ? "install_options => ['--prerelease']," : ''; // eslint-disable-line
                     const storageSpace = findScriptPre(getStorage[3]) ? '       ' : '';
 
-                    commandPuppet.innerHTML += `package { '${storageValue}':
-                      ensure   ${storageSpace} => '${storageVersion}',
-                      ${storagePre}
-                      provider ${storageSpace} => 'chocolatey',
-                      source   ${storageSpace} => '${internalRepoUrl}',
-                    }
-                    
-                    `;
+                    commandPuppet.innerHTML += `
+package { '${storageValue}':
+  ensure   ${storageSpace} => '${storageVersion}',
+  ${storagePre}
+  provider ${storageSpace} => 'chocolatey',
+  source   ${storageSpace} => '${internalRepoUrl}',
+}`;
                 }
 
+                commandPuppet.innerHTML = removeLineBreaks(commandPuppet.innerHTML);
                 highlightScript(commandPuppet, 'language-puppet');
 
                 break;
             case 'generic':
                 commandGenericTwo.innerHTML = `function Install-ChocolateyPackage {
-                  param (
-                    [Parameter(Mandatory, Position=0)]
-                    [string]$PackageName,
+  param (
+    [Parameter(Mandatory, Position=0)]
+    [string]$PackageName,
 
-                    [string]$Source,
+    [string]$Source,
 
-                    [alias("Params")]
-                    [string]$PackageParameters,
+    [alias("Params")]
+    [string]$PackageParameters,
 
-                    [string]$Version,
+    [string]$Version,
 
-                    [alias("Pre")]
-                    [switch]$Prerelease,
+    [alias("Pre")]
+    [switch]$Prerelease,
 
-                    [switch]$UseInstallNotUpgrade
-                  )
+    [switch]$UseInstallNotUpgrade
+  )
 
-                  $chocoExecutionArgs = "choco.exe"
-                  if ($UseInstallNotUpgrade) {
-                    $chocoExecutionArgs += " install"
-                  } else {
-                    $chocoExecutionArgs += " upgrade"
-                  }
+  $chocoExecutionArgs = "choco.exe"
+  if ($UseInstallNotUpgrade) {
+    $chocoExecutionArgs += " install"
+  } else {
+    $chocoExecutionArgs += " upgrade"
+  }
 
-                  $chocoExecutionArgs += " $PackageName -y --source='$Source'"
-                  if ($Prerelease) { $chocoExecutionArgs += " --prerelease"}
-                  if ($Version) { $chocoExecutionArgs += " --version='$Version'"}
-                  if ($PackageParameters -and $PackageParameters -ne '') { $chocoExecutionArgs += " --package-parameters='$PackageParameters'"}
+  $chocoExecutionArgs += " $PackageName -y --source='$Source'"
+  if ($Prerelease) { $chocoExecutionArgs += " --prerelease"}
+  if ($Version) { $chocoExecutionArgs += " --version='$Version'"}
+  if ($PackageParameters -and $PackageParameters -ne '') { $chocoExecutionArgs += " --package-parameters='$PackageParameters'"}
 
-                  Invoke-Expression -Command $chocoExecutionArgs
-                  $exitCode = $LASTEXITCODE
-                  $validExitCodes = @(0, 1605, 1614, 1641, 3010)
-                  if ($validExitCodes -notcontains $exitCode) {
-                    throw "Error with package installation. See above."
-                  }
-                }
+  Invoke-Expression -Command $chocoExecutionArgs
+  $exitCode = $LASTEXITCODE
+  $validExitCodes = @(0, 1605, 1614, 1641, 3010)
+  if ($validExitCodes -notcontains $exitCode) {
+    throw "Error with package installation. See above."
+  }
+}
 
-                <span></span>`;
+<span></span>`;
 
                 for (const i in packages) {
                     const getStorage = packages[i].split(' , ');
@@ -488,7 +488,7 @@ import { copyCodeBlocks, getCookie, selectDeploymentMethodTab } from './util/cho
                     const storagePreOne = findScriptPre(getStorage[3]) ? ' --prerelease' : '';
                     const storagePreTwo = findScriptPre(getStorage[3]) ? ' -Prerelease' : '';
 
-                    commandGenericOne.innerHTML += `choco upgrade ${storageValue} -y --source="'${internalRepoUrl}'" --version "'${storageVersion}"'${storagePreOne} [other options]\n`;
+                    commandGenericOne.innerHTML += `choco upgrade ${storageValue} -y --source="'${internalRepoUrl}'" --version "'${storageVersion}'"${storagePreOne} [other options]\n`;
                     commandGenericTwo.querySelector('span').innerHTML += `Install-ChocolateyPackage ${storageValue} -Source ${internalRepoUrl} -Version ${storageVersion}${storagePreTwo}\n`;
                 }
 

--- a/js/util/chocolatey-functions.js
+++ b/js/util/chocolatey-functions.js
@@ -184,3 +184,10 @@ export const truncateResults = btnId => {
         });
     }
 };
+
+// Remove line breaks
+export const removeLineBreaks = str => {
+    return str.split(/\r?\n/) // Split input text into an array of lines
+        .filter(line => line.trim() !== '') // Filter out lines that are empty or contain only whitespace
+        .join('\n'); // Join line array into a string
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description Of Changes
In Script Builder, there are a number of generated scripts that are
based on user input. These scripts were not indented properly. The
changes here ensure proper indentation for installation usage. A new
global function has also been added that will remove blank line breaks
from a string. This is useful in situations where template literals are
used on separate lines that may or may not contain content.

## Motivation and Context
We need these scripts to be correct.

## Testing
1. Linked locally to community.chocolatey.org

## Change Types Made
* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
* #261 
* https://github.com/chocolatey/home/issues/207

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
