### PR TITLE
(#278)(#279) Update events in flyout and remove maintenance banner

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.1.9"
+    "choco-theme": "0.1.10"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/AlertText.txt
+++ b/partials/AlertText.txt
@@ -1,1 +1,0 @@
-<a class='text-dark' href='https://status.chocolatey.org/issues/2022-11-16-scheduled-maintenance-chocolatey-community-repository-and-website/' target='_blank' rel='noreferrer'>We will be performing scheduled maintenance on the Chocolatey Community Repository (community.chocolatey.org) on Sunday 27th November 2022, between 20:00 and 23:59 UTC.</a>

--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -37,6 +37,41 @@
 </div>
 <hr />
 <div class="text-center">
+    <a href="https://chocolatey.org/events/chocolatey-coding-livestream" rel="noreferrer" target="_blank">
+        <img class="border mb-3" src="https://img.chocolatey.org/events/01-21.jpg" alt="Chocolatey Coding Livestream" />
+    </a>
+    <p class="convert-utc-to-local fw-bold" data-event-utc="2022-11-29T20:00:00Z" data-event-include-break="true"></p>
+    <p class="text-start">Join Josh as he adds the ability to manage Chocolatey GUI config and features with the Chocolatey Ansible Collection.</p>
+    <div class="d-flex align-items-center justify-content-center flex-wrap">
+        <a href="https://chocolatey.org/events/chocolatey-coding-livestream" rel="noreferrer" target="_blank" class="btn btn-outline-primary mt-2 mx-1">Learn More</a>
+        <div class="mt-2 mx-1">
+            <div class="atcb" style="display:none;">
+            {
+                "name":"Chocolatey Coding Livestream",
+                "description":"Join Josh as he adds the ability to manage Chocolatey GUI config and features with the Chocolatey Ansible Collection.",
+                "location":"https://chocolatey.org/events/chocolatey-coding-livestream",
+                "startDate":"2022-11-29",
+                "endDate":"2022-11-29",
+                "startTime":"20:00",
+                "endTime":"21:00",
+                "options":[
+                    "Apple",
+                    "Google",
+                    "iCal",
+                    "Microsoft365",
+                    "Outlook.com",
+                    "Yahoo"
+                ],
+                "trigger":"click",
+                "inline":true,
+                "iCalFileName":"chocolatey-coding-livestream"
+            }
+            </div>
+        </div>
+    </div>
+</div>
+<hr />
+<div class="text-center">
     <a href="https://chocolatey.org/events/chocolatey-spotlight-2022-december" rel="noreferrer" target="_blank">
         <img class="border mb-3" src="https://img.chocolatey.org/events/01-22.jpg" alt="Chocolatey Product Spotlight: A Year in Review" />
     </a>
@@ -69,6 +104,15 @@
             </div>
         </div>
     </div>
+</div>
+<hr />
+<div class="text-center">
+    <a href="https://community.veeam.com/events/introduction-into-chocolatey-80" rel="noreferrer" target="_blank">
+        <img class="border mb-3" src="https://img.chocolatey.org/events/02-03.jpg" alt="Introduction into Chocolatey with Veeam" />
+    </a>
+    <p class="convert-utc-to-local fw-bold" data-event-utc="2022-12-13T17:00:00Z" data-event-include-break="true"></p>
+    <p class="text-start">Join Gary, Paul, and Maurice as they introduce and demonstrate how to use Chocolatey! Questions will be answered live in an Ask Me Anything format.</p>
+   <a href="https://community.veeam.com/events/introduction-into-chocolatey-80" rel="noreferrer" target="_blank" class="btn btn-primary mt-2 mx-1">Register Now</a>
 </div>
 <hr />
 <div class="text-center">
@@ -107,38 +151,12 @@
 </div>
 <hr />
 <div class="text-center">
-    <a href="https://chocolatey.org/events/chocolatey-coding-livestream" rel="noreferrer" target="_blank">
-        <img class="border mb-3" src="https://img.chocolatey.org/events/01-21.jpg" alt="Chocolatey Coding Livestream" />
+    <a href="https://community.veeam.com/automation-desk-103/event-december-chocolatey-month-3720" rel="noreferrer" target="_blank">
+        <img class="border mb-3" src="https://img.chocolatey.org/events/02-04.jpg" alt="December Chocolatey Month with Veeam" />
     </a>
-    <p class="convert-utc-to-local fw-bold" data-event-utc="2022-11-29T20:00:00Z" data-event-include-break="true"></p>
-    <p class="text-start">Join Josh as he adds the ability to manage Chocolatey GUI config and features with the Chocolatey Ansible Collection.</p>
-    <div class="d-flex align-items-center justify-content-center flex-wrap">
-        <a href="https://chocolatey.org/events/chocolatey-coding-livestream" rel="noreferrer" target="_blank" class="btn btn-outline-primary mt-2 mx-1">Learn More</a>
-        <div class="mt-2 mx-1">
-            <div class="atcb" style="display:none;">
-            {
-                "name":"Chocolatey Coding Livestream",
-                "description":"Join Josh as he adds the ability to manage Chocolatey GUI config and features with the Chocolatey Ansible Collection.",
-                "location":"https://chocolatey.org/events/chocolatey-coding-livestream",
-                "startDate":"2022-11-29",
-                "endDate":"2022-11-29",
-                "startTime":"20:00",
-                "endTime":"21:00",
-                "options":[
-                    "Apple",
-                    "Google",
-                    "iCal",
-                    "Microsoft365",
-                    "Outlook.com",
-                    "Yahoo"
-                ],
-                "trigger":"click",
-                "inline":true,
-                "iCalFileName":"chocolatey-coding-livestream"
-            }
-            </div>
-        </div>
-    </div>
+    <p class="fw-bold">December 2022</p>
+    <p class="text-start">Join Veeam and Chocolatey in the month of December in the Automation Desk group to answer questions, gain points, and win prizes.</p>
+    <a href="https://community.veeam.com/automation-desk-103/event-december-chocolatey-month-3720" rel="noreferrer" target="_blank" class="btn btn-primary mt-2 mx-1">Register</a>
 </div>
 <hr />
 <div class="shuffle">


### PR DESCRIPTION
## Description Of Changes
* Removes maintenance banner
* Adds two new events into the right side flyout

## Motivation and Context
The banner was no longer relevant and needed to be removed. We also are two new events coming up that should be added to the flyout to stay up to date. 

## Testing
1. Linked to chocolatey.org locally to ensure the banner no longer showed.
2. Opened the right side flyout to ensure the events added were there, links worked and images showed correctly.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/278
* https://github.com/chocolatey/choco-theme/issues/279
* https://github.com/chocolatey/chocolatey.org/issues/206
* https://github.com/chocolatey/chocolatey.org/issues/207
* https://github.com/chocolatey/home/issues/226
* https://github.com/chocolatey/home/issues/227
* https://gitlab.com/chocolatey/community-infrastructure/community.chocolatey.org/-/issues/1192
* https://gitlab.com/chocolatey/community-infrastructure/community.chocolatey.org/-/issues/1191
* https://github.com/chocolatey/docs/issues/602
* https://github.com/chocolatey/blog/issues/197
* https://github.com/chocolatey/boxstarter.org/issues/31

## Related PRs
* https://github.com/chocolatey/choco-theme/pull/281
