### PR TITLE
(#286) Update Link in Right Side Flyout

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.1.12"
+    "choco-theme": "0.1.13"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -127,12 +127,12 @@
         <hr />
     </div>
     <div class="text-center">
-        <a href="https://youtube.com/@veeam" rel="noreferrer" target="_blank">
+        <a href="https://youtube.com/@@veeam" rel="noreferrer" target="_blank">
             <img class="border mb-3" src="https://img.chocolatey.org/events/02-03.jpg" alt="Introduction into Chocolatey with Veeam" />
         </a>
         <p><strong>Webinar from<br />Tuesday, 13 December 2022</strong></p>
         <p class="text-start">Join Gary, Paul, and Maurice as they introduce and demonstrate how to use Chocolatey! Questions will be answered live in an Ask Me Anything format.</p>
-        <a href="https://youtube.com/@veeam" rel="noreferrer" target="_blank" class="btn btn-primary mt-2 mx-1">Watch On-Demand</a>
+        <a href="https://youtube.com/@@veeam" rel="noreferrer" target="_blank" class="btn btn-primary mt-2 mx-1">Watch On-Demand</a>
         <hr />
     </div>
 </div>


### PR DESCRIPTION
## Description Of Changes
This updates the link in the right side flyout to contain a `@@` in `https://youtube.com/@@veeam` which is needed in order to render correctly.

## Motivation and Context
We need event links to be up to date.

## Testing
1. Linked to chocolatey.org locally.

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* ENGTASKS-2663
* https://github.com/chocolatey/choco-theme/issues/286
* https://github.com/chocolatey/home/issues/235
* https://github.com/chocolatey/chocolatey.org/issues/217
* https://gitlab.com/chocolatey/community-infrastructure/community.chocolatey.org/-/issues/1200

