### PR TITLE
(#296)(#297) Allow Buttons to Wrap in Flyout

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.2.4"
+    "choco-theme": "0.2.5"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/js/chocolatey-events.js
+++ b/js/chocolatey-events.js
@@ -81,7 +81,7 @@ import { DateTime } from 'luxon';
     };
 
     const replaceElapsed = () => {
-        jQuery('.countdown-details').add(countdownContainer).add(jQuery('.countdown-date')).add(jQuery('.btn-not-on-demand')).add(jQuery('.btn-add-to-calendar')).remove();
+        jQuery('.countdown-details').add(countdownContainer).add(jQuery('.countdown-date')).add(jQuery('.btn-not-on-demand')).remove();
         jQuery('a:not(.btn-sidebar), h3').each((index, element) => {
             jQuery(element).html(jQuery(element).html()
                 .replace('Reserve My Spot Now', ellapsedButtonText)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/CollapsingRightSidebarContent.txt
+++ b/partials/CollapsingRightSidebarContent.txt
@@ -41,7 +41,7 @@
         <img class="border rounded mb-3" src="https://img.chocolatey.org/events/01-15-2.jpg" alt="Chocolatey Community Coffee Break" />
     </a>
     <p class="text-start">Join the Chocolatey Team on our regular monthly stream where we discuss all things Community, what we do, how you can get involved and answer your Chocolatey questions.</p>
-    <div class="d-flex justify-content-center">
+    <div class="d-flex justify-content-center flex-wrap">
         <div class="btn-add-to-calendar mt-2 mx-1">
             <span id="FlyoutCalendarButtonCoffeeBreak"></span>
         </div>
@@ -54,7 +54,7 @@
         <img class="border rounded mb-3" src="https://img.chocolatey.org/events/01-23.jpg" alt="Chocolatey Product Spotlight" />
     </a>
     <p class="text-start">Join the Chocolatey Team on our regular monthly stream where we put a spotlight on the most recent Chocolatey product releases. You'll have a chance to have your questions answered in a live Ask Me Anything format.</p>
-    <div class="d-flex justify-content-center">
+    <div class="d-flex justify-content-center flex-wrap">
         <div class="btn-add-to-calendar mt-2 mx-1">
             <span id="FlyoutCalendarButtonProductSpotlight"></span>
         </div>


### PR DESCRIPTION
## Description Of Changes
With the addition of the Add to Calendar buttons, there are now two buttons in the flyout next to each other. A new class has been added to the containing div to allow to buttons to wrap properly on smaller screens.

In addition, a small enhancement to the JS has been made to not remove the Add to Calendar buttons on an event page after the event time is over. This is due to the Add to Calendar buttons now containing more than just one event date.

## Motivation and Context
Buttons were wrapping oddly on the /pacakges page.

## Testing
1. Linked to chocolatey.org locally and made the viewport small so the buttons would wrap. Ensured they wrapped correctly.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* ENGTASKS-1314
* ENGTASKS-2688
* ENGTASKS-2559
* https://github.com/chocolatey/choco-theme/issues/296
* https://github.com/chocolatey/choco-theme/issues/297
* https://github.com/chocolatey/chocolatey.org/issues/225
* https://github.com/chocolatey/chocolatey.org/issues/226
* https://github.com/chocolatey/home/issues/240
* https://github.com/chocolatey/home/issues/241
* https://gitlab.com/chocolatey/community-infrastructure/community.chocolatey.org/-/issues/1203
* https://gitlab.com/chocolatey/community-infrastructure/community.chocolatey.org/-/issues/1204

