### PR TITLE
(#304) Enable Tabs on docs

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.2.5"
+    "choco-theme": "0.2.6"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/js/init/chocolatey-docs.js
+++ b/js/init/chocolatey-docs.js
@@ -1,4 +1,4 @@
-import { Alert, Button, Collapse } from 'bootstrap';
+import { Alert, Button, Collapse, Tab } from 'bootstrap';
 import '../lib/prism.min.js';
 import '../chocolatey-alerts.js';
 import '../chocolatey-anchors.js';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description Of Changes
The appropriate JavaScript has been updated to allow usage of the Bootstrap Tab on docs.chocolatey.org

## Motivation and Context
We would like to use the tab component, and this is a requirement.

## Testing
1. Linked to docs.chocolatey.org locally
2. Ensured the tab component worked as expected.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* #304
* https://github.com/chocolatey/docs/issues/661 

