### PR TITLE
(#320) Move to Google Analytics

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.4.0"
+    "choco-theme": "0.4.1"
   },
   "resolutions": {
     "glob-parent": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/GoogleTag.html
+++ b/partials/GoogleTag.html
@@ -1,0 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-0WDD29GGN2"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-0WDD29GGN2');
+</script>


### PR DESCRIPTION
## Description Of Changes
Google is sunsetting Universal Analytics, so it was necessary to move over to Google Analytics. In this move, all code associated with it has been moved into choco-theme, so that it can be managed in one place going forward.

## Motivation and Context
Google is sunsetting Universal Analytics, so it was necessary to move over to Google Analytics.

## Testing
1. Ran locally with all websites that use choco-theme and ensured tag was found 

### Operating Systems Testing
n/a

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
- ENGTASKS-1768
- #320 
