### PR TITLE
(#328) Update Product Spotlight time and date

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.5.1"
+    "choco-theme": "0.5.2"
   },
   "resolutions": {
     "glob-parent": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/CalendarButtonProductSpotlight.html
+++ b/partials/CalendarButtonProductSpotlight.html
@@ -4,11 +4,6 @@
         "description":"Join the Chocolatey Team on our regular monthly stream where we put a spotlight on the most recent Chocolatey product releases. You'll have a chance to have your questions answered in a live Ask Me Anything format.",
         "dates":[
             {
-                "startDate":"2023-05-18",
-                "startTime":"16:00",
-                "endTime":"17:00"
-            },
-            {
                 "startDate":"2023-06-01",
                 "startTime":"16:00",
                 "endTime":"17:00"


### PR DESCRIPTION
## Description Of Changes
This removes the Product Spotlight event for the 18th of May, 2023. It
has been cancelled.

## Motivation and Context
This event has been cancelled.

## Testing
1. Linked to chocolatey.org to ensure the date no longer showed on the Add to Calendar buttons.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* ENGTASKS-3109
* #328 
