### PR TITLE
(#332) Remove leading white space in downloaded xml file from Script Builder

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.5.3"
+    "choco-theme": "0.5.4"
   },
   "resolutions": {
     "glob-parent": "^6.0.2",

--- a/js/chocolatey-script-builder.js
+++ b/js/chocolatey-script-builder.js
@@ -646,7 +646,7 @@ package { '${storageValue}':
     const download = (filename, text) => {
         const element = document.createElement('a');
 
-        element.setAttribute('href', `data:text/xml;charset=utf-8, ${encodeURIComponent(text)}`);
+        element.setAttribute('href', `data:text/xml;charset=utf-8,${encodeURIComponent(text)}`);
         element.setAttribute('download', filename);
         element.style.display = 'none';
         document.body.appendChild(element);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description Of Changes
After a bit of debugging, it was found that the problem of the extra
leading space was not in the generation of the file, but in how it was
being downloaded. When setting the `href`of the created element, there
was an extra space before the text was included. Normally, extra spaces
like this are not a problem, but because of the type of function being
performed, this extra space made it's way into the downloaded xml file.

By removing this space, there is now no leading white space in the
generated xml file from Script Builder.

## Motivation and Context
The extra leading white space was causing errors when the user tried to install packages with it.

## Testing
1. Linked choco-theme locally to community.chocolatey.org
2. Added a package to Script Builder
3. Chose "Individual" in Script Builder, and on Step 3, downloaded the xml file.
4. Opened the xml file to ensure that there was no leading white space like what the original issue had.

### Operating Systems Testing
n/a

## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* #332 
* https://github.com/chocolatey/home/issues/256


Fixes #332
