### PR TITLE
(#285) Pin Bootstrap to 5.2.3

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.5.4"
+    "choco-theme": "0.5.5"
   },
   "resolutions": {
     "glob-parent": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "add-to-calendar-button": "^1.18.8",
     "anchor-js": "^4.3.1",
     "babelify": "^10.0.0",
-    "bootstrap": "^5.2.2",
+    "bootstrap": "5.2.3",
     "browserify": "^17.0.0",
     "canvas-confetti": "^1.5.1",
     "chartist": "^0.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description Of Changes
A new stable version of Bootstrap, 5.3.0, has been released, however this does
cause a few things to break in choco-theme. It is best to pin Bootstrap to the
last known version to work, 5.2.3, until a proper upgrade can be done. If this
version is not pinned, then 5.3 will be pulled automatically on upgrade of
choco-theme, which is not intended.

## Motivation and Context
If this version is not pinned, then 5.3 will be pulled automatically on upgrade of
choco-theme, which is not intended.

## Testing
n/a

### Operating Systems Testing
n/a

## Change Types Made
* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* #285 



<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
