### PR TITLE
(#341) Update event dates and times

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.5.6"
+    "choco-theme": "0.5.7"
   },
   "resolutions": {
     "glob-parent": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/CalendarButtonCoffeeBreak.html
+++ b/partials/CalendarButtonCoffeeBreak.html
@@ -4,11 +4,6 @@
         "description":"Join the Chocolatey Team on our regular monthly stream where we discuss all things Community, what we do, how you can get involved and answer your Chocolatey questions.",
         "dates":[
             {
-                "startDate":"2023-06-15",
-                "startTime":"16:00",
-                "endTime":"17:00"
-            },
-            {
                 "startDate":"2023-07-20",
                 "startTime":"16:00",
                 "endTime":"17:00"

--- a/partials/CalendarButtonProductSpotlight.html
+++ b/partials/CalendarButtonProductSpotlight.html
@@ -4,11 +4,6 @@
         "description":"Join the Chocolatey Team on our regular monthly stream where we put a spotlight on the most recent Chocolatey product releases. You'll have a chance to have your questions answered in a live Ask Me Anything format.",
         "dates":[
             {
-                "startDate":"2023-06-01",
-                "startTime":"16:00",
-                "endTime":"17:00"
-            },
-            {
                 "startDate":"2023-07-06",
                 "startTime":"16:00",
                 "endTime":"17:00"


### PR DESCRIPTION
## Description Of Changes
The next upcoming Coffee Break has been cancelled, and
the old Product Spotlight event have been removed from
the Add to Calendar button partials. This will prevent
users from seeing these dates and will not allow them
to be added to their calendars.

## Motivation and Context
We don't want out of date events on our website.

## Testing
1. Linked to chocoaltey.org locally to ensure dates were not added to the Add to Calendar buttons when clicking on each event.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
#341
