### PR TITLE
(#351) Allow Standard Support at < 100 nodes

### DIFF
--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.5.11"
+    "choco-theme": "0.5.12"
   },
   "resolutions": {
     "glob-parent": "^6.0.2",

--- a/js/chocolatey-pricing-calculator.js
+++ b/js/chocolatey-pricing-calculator.js
@@ -47,7 +47,7 @@ window.addEventListener('DOMContentLoaded', () => {
             let c4bPackagingCalculatedPrice = 0;
 
             // Find Standard Support Add-On Price
-            if (c4bSliderNumberOfNodes >= c4bSupportNodes[0].community && c4bSliderNumberOfNodes < c4bSupportNodes[0].standard && c4bStandardSupport.checked) {
+            if (c4bSliderNumberOfNodes < c4bSupportNodes[0].standard && c4bStandardSupport.checked) {
                 c4bStandardSupportCalculatedPrice = c4bAddOnPrice[0].standardSupport;
             }
 
@@ -312,10 +312,10 @@ window.addEventListener('DOMContentLoaded', () => {
             // Update the previous value
             c4bPreviousNodes = values[handle];
 
-            if (values[handle] < c4bSupportNodes[0].community || (values[handle] < c4bSupportNodes[0].standard && !c4bStandardSupport.classList.contains('active'))) {
+            if (values[handle] < c4bSupportNodes[0].standard && !c4bStandardSupport.classList.contains('active')) {
                 c4bCommunitySupport.checked = true;
             } else if ((values[handle] >= c4bSupportNodes[0].standard && values[handle] < c4bSupportNodes[0].premium) ||
-                ((values[handle] >= c4bSupportNodes[0].community && values[handle] < c4bSupportNodes[0].standard) && c4bStandardSupport.classList.contains('active')) ||
+                (values[handle] < c4bSupportNodes[0].standard && c4bStandardSupport.classList.contains('active')) ||
                 (values[handle] >= c4bSupportNodes[0].premium && !c4bPremiumSupport.classList.contains('active'))) {
                 c4bStandardSupport.checked = true;
             } else if (values[handle] >= c4bSupportNodes[0].premium && c4bPremiumSupport.classList.contains('active')) {
@@ -323,12 +323,6 @@ window.addEventListener('DOMContentLoaded', () => {
             }
 
             // Enable/Disable toggling of support type
-            if (values[handle] < c4bSupportNodes[0].community) {
-                c4bStandardSupport.disabled = true;
-            } else {
-                c4bStandardSupport.disabled = false;
-            }
-
             if (values[handle] >= c4bSupportNodes[0].standard) {
                 c4bCommunitySupport.disabled = true;
             } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description Of Changes
This allows the Standard Support option to be selected at < 100 nodes, but still places it as an add-on until the node count is >= 100.

## Motivation and Context
This should be able to to be selected with < 100 nodes.

## Testing
1. Run the PR at https://github.com/chocolatey/chocolatey.org/pull/269
2. Run the playwright test once the website is running `yarn run playwright`.
3. If wanted, on the home page, manually slide or input 33 nodes and observe how the Standard Support option is still available to select and is not disabled. 
    1. Click the Standard Support option, it is added to the Add On Container on the right and the price is adjusted.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* https://github.com/chocolatey/chocolatey.org/issues/270
* https://github.com/chocolatey/choco-theme/issues/351
