### PR TITLE
(#355) Remediate SASS Depreciation Warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "mousetrap": "^1.6.5",
     "nouislider": "^15.7.0",
     "rimraf": "^3.0.2",
-    "sass": "^1.53.0",
+    "sass": "~1.64.2",
     "stylelint": "^14.14.0",
     "stylelint-config-standard": "^29.0.0",
     "stylelint-config-standard-scss": "^5.0.0",

--- a/scss/variables/_boxstarter.scss
+++ b/scss/variables/_boxstarter.scss
@@ -57,8 +57,8 @@ $alert-border-radius:               0;
 $alert-border-width:                0;
 $alert-margin-bottom:               0;
 $alert-border-width:                0;
-$alert-bg-scale:                    0;
-$alert-color-scale:                 0;
+$alert-bg-scale:                    0%;
+$alert-color-scale:                 0%;
 
 // Tabs
 $nav-tabs-link-active-bg:           $white;

--- a/scss/variables/_chocolatey.scss
+++ b/scss/variables/_chocolatey.scss
@@ -45,8 +45,8 @@ $alert-border-radius: 0;
 $alert-border-width: 0;
 $alert-margin-bottom: 0;
 $alert-border-width: 0;
-$alert-bg-scale: 0;
-$alert-color-scale: 0;
+$alert-bg-scale: 0%;
+$alert-color-scale: 0%;
 
 // Tabs
 $nav-tabs-link-active-bg: $white;


### PR DESCRIPTION
## Description Of Changes

This remediates two SASS depreciation warnings that were occurring when running `gulp`. The version of SASS choco-theme uses has been pinned to a specific major and minor version, while still allowing patch releases.

In addition, a percentage has been passed to a SASS variable instead of just 0, as required.

## Motivation and Context

These were warnings that were taking up a bunch of space in the gulp output, and fixes have been provided for them.

## Testing
1. Pull down this PR
2. Ensure you have a repository that is sitting adjacent to the choco-theme repository on your machine (docs, blog, chocolatey.org) and you are on the master/main branch.
3. Run `yarn` in the adjacent repository.
1. Run `gulp`, in the adjacent repository and notice the red depreciation warnings in the gulp output.
4. Delete the `yarn.lock` file in the adjacent repository.
5. Run `yarn link ../choco-theme` in the adjacent repository.
6. Run `gulp` in the adjacent repository. You will see warnings related to color contrast ratios, but no others.
7. When finished, run `yarn unlink` in the adjacent repository to stop the sync.

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
 #355 

Fixes #355
