### PR TITLE
(#357) Add Bluesky social media link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "atcb",
         "blockquotes",
+        "bluesky",
         "Boxstarter",
         "callouts",
         "camelcase",

--- a/getting-started/_package.json
+++ b/getting-started/_package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/chocolatey/chocolatey.org#readme",
   "devDependencies": {
-    "choco-theme": "0.5.13"
+    "choco-theme": "0.5.14"
   },
   "resolutions": {
     "glob-parent": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-theme",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "The global theme for Chocolatey Software.",
   "repository": {
     "type": "git",

--- a/partials/socialmedia.txt
+++ b/partials/socialmedia.txt
@@ -62,4 +62,11 @@
             </div>
         </a>
     </li>
+    <li class="list-inline-item">
+        <a href="https://bsky.app/profile/chocolatey.org" target="_blank" rel="me" aria-label="Connect with Chocolatey on Bluesky" title="Connect with Chocolatey on Bluesky">
+            <div class="text-bg-bluesky circle" aria-hidden="true">
+                <i class="fa-solid fa-cubes"></i>
+            </div>
+        </a>
+    </li>
 </ul>

--- a/scss/variables/_global.scss
+++ b/scss/variables/_global.scss
@@ -15,6 +15,7 @@ $chat:      #5865f2; // No automatic contrasting color
 $google:    #4285f4;
 $website:   $gray-600;
 $mastodon:  #6364ff;
+$bluesky:   #0085ff;
 
 // Palette
 $primary-50:   tint-color($primary, 90%);
@@ -214,7 +215,8 @@ $socialmedia-colors: (
     chat:     $chat,
     google:   $google,
     website:  $website,
-    mastodon: $mastodon
+    mastodon: $mastodon,
+    bluesky:  $bluesky
 );
 
 $palette-colors: (


### PR DESCRIPTION
## Description Of Changes
This adds a Bluesky social media link to the list of social media icons that are shown in various places on the Chocolatey websites.

## Motivation and Context
We are on Bluesky but we don't have a link for it at all.

## Testing
1. Ran the PR at https://github.com/chocolatey/chocolatey.org/pull/
2. Ensured the social links showed as in the pictures below.

![Screenshot 2023-10-19 at 11 24 12 AM](https://github.com/chocolatey/choco-theme/assets/42750725/6b0338e2-4d6b-49f5-8bbf-4dab3e5022ac)
![Screenshot 2023-10-19 at 11 24 32 AM](https://github.com/chocolatey/choco-theme/assets/42750725/d84c5a93-f135-4521-be22-1c56a8600563)

From the blog PR (not set up to run this version of choco-theme): 

![Screenshot 2023-10-19 at 11 26 13 AM](https://github.com/chocolatey/choco-theme/assets/42750725/188bc1dd-6a6b-4505-aaed-73a15db729f4)

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist
* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/357
* https://github.com/chocolatey/home/issues/280
* https://github.com/chocolatey/chocolatey.org/issues/285
* https://gitlab.com/chocolatey/community-infrastructure/community.chocolatey.org/-/issues/1239
* https://github.com/chocolatey/blog/issues/239
