### PR TITLE
(build) Update publish workflow for Yarn 4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,6 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@chocolatey-software'
       - run: yarn
-      - run: yarn publish --access public
+      - run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description Of Changes
With Yarn 4, the publish command changed to
`yarn npm publish` and this needs updated here to
allow choco-theme to publish to npm correctly.

This has been tested to work via the command line
to release 0.6.0.

## Motivation and Context
We need this action to work.

## Testing
This was tested to release version 0.6.0 of choco-theme, that is [found here](https://www.npmjs.com/package/choco-theme/v/0.6.0).

### Operating Systems Testing
n/a

## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
n/a
