### PR TITLE
(#400) Allow GitHub Action to publish to NPM

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ checksumBehavior: update
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.1.1.cjs
+
+npmAuthToken: ${NODE_AUTH_TOKEN-fallback}


### PR DESCRIPTION
## Description Of Changes
As found in the Yarn docs, by adding a
`-fallback` onto the passed in environment
variable, if one is not supplied, it will
"fallback" to a default value. This is exactly
what is needed in order for repositories to use
choco-theme that do not have this environment
variable set. This will allow GitHub Actions to
publish to NPM and also allow repositories to
install choco-theme like normal.

Per Yarn documentation:


> Environment variables can be accessed from setting definitions by using the ${NAME} syntax when defining the values. By default Yarn will require the variables to be present, but this can be turned off by using either ${NAME-fallback} (which will return fallback if NAME isn't set) or ${NAME:-fallback} (which will return fallback if NAME isn't set, or is an empty string).

## Motivation and Context
We need the GitHub action to run, and also to install on other repositories without having the environment variable set.

## Testing
1. Cloned down this branch and also a repository that uses choco-theme
2. From the repository that runs choco-theme, I ran `yarn link ../choco-theme` to create a link to the repositories. 
3. This succeeded like normally. Without this change to choc-theme, this would fail if the environment variable was present in choco-theme.

### Operating Systems Testing
n/a

## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
#400 

Fixes #400
