### PR TITLE
(#422) yarn preview-upgrade improvements

### DIFF
--- a/build/data/preview-config.ts
+++ b/build/data/preview-config.ts
@@ -24,6 +24,14 @@ export const folderMapping: FolderMapping = {
         isStatiq: true,
         isAstro: false
     },
+    '--ccm': {
+        folder: 'choco-licensed-management-ui',
+        protocol: 'https',
+        port: 44302,
+        isStatiq: false,
+        isAstro: false,
+        root: '/src/ChocolateySoftware.ChocolateyManagement.Web.Mvc'
+    },
     '--boxstarter': {
         folder: 'boxstarter.org',
         port: 5083,

--- a/build/preview-upgrade.ts
+++ b/build/preview-upgrade.ts
@@ -52,6 +52,13 @@ const init = async () => {
         }
 
         try {
+            await fs.rm(`${folderPath}/yarn.lock`, { force: true });
+            console.log(`✅ ${folderName} yarn.lock removed`);
+        } catch (error) {
+            throw new Error(`Error removing yarn.lock: ${error.message}`);
+        }
+
+        try {
             const childProcess = spawn(`yarn up choco-theme@${url}`, [], {
                 // stdio: 'inherit', // Use 'inherit' to directly pipe the output to the parent process
                 shell: true, // Needed for Windows to execute .sh files


### PR DESCRIPTION
## Description Of Changes
This adjust the yarn preview-upgrade command to first remove the yarn.lock file in the chosen repository before upgrading choco-theme. By doing this, it ensures all dependencies are upgraded of choco-theme and not just choco-theme itself. This is desired in most cases.

Also, the CCM repository has been added to the list of configs, so that is caught when using the --all or --ccm flag on yarn commands.

## Motivation and Context
This command was not properly updating dependences and needed to be fixed.

## Testing
1. Pull down this branch.
2. On CCM, make sure you are on the `develop` branch and you have the latest changes pulled in from upstream.
3. In choco-theme, run `yarn preview-upgrade 0.8.1 --ccm`
4. You should see multiple things changed in the yarn.lock file in the CCM project repository. Do not commit anything, we're just checking to see that it caught "things".

### Operating Systems Testing
Windows 10

## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
Fixes #422 
