### PR TITLE
Fixes issue with Mastadon link not loading chocolatey page

### DIFF
--- a/dist/partials/astro/SocialMedia.astro
+++ b/dist/partials/astro/SocialMedia.astro
@@ -56,7 +56,7 @@
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://fosstodon.org/@@chocolatey" class="link-underline-none" target="_blank" rel="me" aria-label="Connect with Chocolatey on Mastodon" title="Connect with Chocolatey on Mastodon">
+        <a href="https://fosstodon.org/@chocolatey" class="link-underline-none" target="_blank" rel="me" aria-label="Connect with Chocolatey on Mastodon" title="Connect with Chocolatey on Mastodon">
             <div class="text-bg-mastodon circle" aria-hidden="true">
                 <i class="fa-brands fa-mastodon"></i>
             </div>

--- a/dist/partials/cshtml/_SocialMedia.cshtml
+++ b/dist/partials/cshtml/_SocialMedia.cshtml
@@ -56,7 +56,7 @@
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://fosstodon.org/@@chocolatey" class="link-underline-none" target="_blank" rel="me" aria-label="Connect with Chocolatey on Mastodon" title="Connect with Chocolatey on Mastodon">
+        <a href="https://fosstodon.org/@chocolatey" class="link-underline-none" target="_blank" rel="me" aria-label="Connect with Chocolatey on Mastodon" title="Connect with Chocolatey on Mastodon">
             <div class="text-bg-mastodon circle" aria-hidden="true">
                 <i class="fa-brands fa-mastodon"></i>
             </div>

--- a/partials/SocialMedia.html
+++ b/partials/SocialMedia.html
@@ -56,7 +56,7 @@
         </a>
     </li>
     <li class="list-inline-item">
-        <a href="https://fosstodon.org/@@chocolatey" class="link-underline-none" target="_blank" rel="me" aria-label="Connect with Chocolatey on Mastodon" title="Connect with Chocolatey on Mastodon">
+        <a href="https://fosstodon.org/@chocolatey" class="link-underline-none" target="_blank" rel="me" aria-label="Connect with Chocolatey on Mastodon" title="Connect with Chocolatey on Mastodon">
             <div class="text-bg-mastodon circle" aria-hidden="true">
                 <i class="fa-brands fa-mastodon"></i>
             </div>


### PR DESCRIPTION
## Description Of Changes
Remove extra @ on the Chocolatey Mastaon link.

## Motivation and Context
Fixes issue with Chocolatey page on Mastadon not loading from link on blog.

## Testing
1. Run website.
2. Navigate to blog home page.
3. Under Stay Connected click Mastadon icon.

### Operating Systems Testing
Windows 11 Pro

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
#458 

Fixes #458 
