### PR TITLE
(#489) Remove Token for Trusted Publishing

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,11 +4,8 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs
 
-npmAuthToken: "${NODE_AUTH_TOKEN-fallback}"
-
 npmRegistryServer: "https://registry.npmjs.org"
 
 npmScopes:
   chocolatey-software:
     npmRegistryServer: "https://registry.npmjs.org"
-    npmAuthToken: "${NODE_AUTH_TOKEN-fallback}"


### PR DESCRIPTION
## Description Of Changes
This removes the token that would have been used if Trusted Publishing was not setup. Since it is setup, but there is still a token here, it tries to use it which causes a 404 error. Removing this token will enable the workflow to properly publish Trusted Packages.

## Motivation and Context
We want this workflow to run successfully.

## Testing
n/a

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
* #489 
