### PR TITLE
(#536) Add note to Terms of Service

### DIFF
--- a/packages/blog/dist/partials/TermsContent.astro
+++ b/packages/blog/dist/partials/TermsContent.astro
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/blog/dist/partials/TermsLastUpdated.astro
+++ b/packages/blog/dist/partials/TermsLastUpdated.astro
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/blog/package.json
+++ b/packages/blog/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/blog",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on blog.chocolatey.org.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/blog#readme",

--- a/packages/boxstarter/dist/partials/_TermsContent.cshtml
+++ b/packages/boxstarter/dist/partials/_TermsContent.cshtml
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/boxstarter/dist/partials/_TermsLastUpdated.cshtml
+++ b/packages/boxstarter/dist/partials/_TermsLastUpdated.cshtml
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/boxstarter/package.json
+++ b/packages/boxstarter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/boxstarter",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on boxstarter.org.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/boxstarter#readme",

--- a/packages/ccr/dist/partials/_TermsContent.cshtml
+++ b/packages/ccr/dist/partials/_TermsContent.cshtml
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/ccr/dist/partials/_TermsLastUpdated.cshtml
+++ b/packages/ccr/dist/partials/_TermsLastUpdated.cshtml
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/ccr/package.json
+++ b/packages/ccr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/ccr",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on community.chocolatey.org",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/ccr#readme",

--- a/packages/credits/dist/partials/TermsContent.astro
+++ b/packages/credits/dist/partials/TermsContent.astro
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/credits/dist/partials/TermsLastUpdated.astro
+++ b/packages/credits/dist/partials/TermsLastUpdated.astro
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/credits/package.json
+++ b/packages/credits/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/credits",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for generating credits.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/credits-generator#readme",

--- a/packages/design/dist/partials/_TermsContent.cshtml
+++ b/packages/design/dist/partials/_TermsContent.cshtml
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/design/dist/partials/_TermsLastUpdated.cshtml
+++ b/packages/design/dist/partials/_TermsLastUpdated.cshtml
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/design",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on design.chocolatey.org.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/design#readme",

--- a/packages/docs/dist/partials/TermsContent.astro
+++ b/packages/docs/dist/partials/TermsContent.astro
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/docs/dist/partials/TermsLastUpdated.astro
+++ b/packages/docs/dist/partials/TermsLastUpdated.astro
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/docs",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on docs.chocolatey.org.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/docs#readme",

--- a/packages/fest/dist/partials/_TermsContent.cshtml
+++ b/packages/fest/dist/partials/_TermsContent.cshtml
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/fest/dist/partials/_TermsLastUpdated.cshtml
+++ b/packages/fest/dist/partials/_TermsLastUpdated.cshtml
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/fest/package.json
+++ b/packages/fest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/fest",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on chocolateyfest.com.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/fest#readme",

--- a/packages/licensing/dist/partials/_TermsContent.cshtml
+++ b/packages/licensing/dist/partials/_TermsContent.cshtml
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/licensing/dist/partials/_TermsLastUpdated.cshtml
+++ b/packages/licensing/dist/partials/_TermsLastUpdated.cshtml
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/licensing/package.json
+++ b/packages/licensing/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/licensing",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for licensing.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/licensing#readme",

--- a/packages/org/dist/partials/_TermsContent.cshtml
+++ b/packages/org/dist/partials/_TermsContent.cshtml
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/org/dist/partials/_TermsLastUpdated.cshtml
+++ b/packages/org/dist/partials/_TermsLastUpdated.cshtml
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/org/package.json
+++ b/packages/org/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/org",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on chocolatey.org.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/org#readme",

--- a/packages/zendesk/dist/partials/termscontent.hbs
+++ b/packages/zendesk/dist/partials/termscontent.hbs
@@ -110,13 +110,13 @@ partial: termscontent
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/packages/zendesk/dist/partials/termslastupdated.hbs
+++ b/packages/zendesk/dist/partials/termslastupdated.hbs
@@ -1,4 +1,4 @@
 ---
 partial: termslastupdated
 ---
-Last updated 21 May 2026
+Last updated 3 June 2026

--- a/packages/zendesk/package.json
+++ b/packages/zendesk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/zendesk",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Chocolatey Software theme assets for use on Zendesk.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/zendesk#readme",

--- a/src/partials/TermsContent.html
+++ b/src/partials/TermsContent.html
@@ -107,13 +107,13 @@
 </p>
 <ul>
     <li>
-        Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
+        <span><strong>Effective as of 1 January 2027:</strong></span> Use the Site and associated services for purposes of managing organizational computers. Organizations using Chocolatey products should not use the Chocolatey Community Repository directly, instead using other repositories, such as their own internal repositories. Exceptions to this include:
         <ul>
             <li>
-                The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
+                <span><strong>Effective as of 1 January 2027:</strong></span> The use of package repository solutions that use the Chocolatey Community Repository as an "upstream" to cache packages locally on that repository server.
             </li>
             <li>
-                Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
+                <span><strong>Effective as of 1 January 2027:</strong></span> Managing software on your personally-administered work computer using Chocolatey CLI, outside of centralized organizational IT controls.
             </li>
         </ul>
     </li>

--- a/src/partials/TermsLastUpdated.html
+++ b/src/partials/TermsLastUpdated.html
@@ -1,1 +1,1 @@
-Last updated 21 May 2026
+Last updated 3 June 2026


### PR DESCRIPTION
## Description Of Changes
This adds a note to 3 bullet points stating that the changes will go
into effect 1 January 2027. Once the new year has arrived, these notes
will be removed.

## Motivation and Context
We want to be clear that the specific items on the terms of service go into effect with the new year, and not right now.

## Testing

With these changes, it will look like the below picture:

<img width="430" height="270" alt="image" src="https://github.com/user-attachments/assets/16f29398-3151-4835-a069-19750a6b4ff1" />


### Operating Systems Testing
Dev VM 4.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
* #536 
* #530
