### PR TITLE
(#549) Replace HTML template literals with DOM API

### DIFF
--- a/packages/build-tools/build/data/repository-config.ts
+++ b/packages/build-tools/build/data/repository-config.ts
@@ -180,6 +180,7 @@ repositoryConfig.ccm.purgeCss = {
         /^selected/,
         /^dt-column-header/,
         /^fa-(brands|google|twitter|x-twitter|square-x-twitter|google|microsoft|facebook|facebook-f|square-facebook)/,
+        /^alert-(warning|danger|success|info)/,
     ]
 };
 

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/build-tools",
-    "version": "2.10.0",
+    "version": "2.12.0",
     "description": "Chocolatey Software build tools.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/build-tools#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/core",
-    "version": "2.10.0",
+    "version": "2.12.0",
     "description": "Theme assets for use on Chocolatey Software websites.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/core#readme",

--- a/packages/core/src/scripts/util/toast-trigger.js
+++ b/packages/core/src/scripts/util/toast-trigger.js
@@ -2,41 +2,74 @@ export const toastTrigger = (toastMessage, type) => {
     let toastType;
     let toastIcon;
     const toastContainer = document.querySelector('.toast-container');
-    const toastNumber = () => Math.floor(100000 + Math.random() * 900000);
-    const toastId = `toast${toastNumber()}`;
+    const toastId = `toast${Math.floor(100000 + Math.random() * 900000)}`;
 
     switch (type) {
         case 'error':
             toastType = 'text-bg-danger';
-            toastIcon = '<i class="fa-solid fa-ban me-1"></i>';
+            toastIcon = 'fa-solid fa-ban';
             break;
         case 'warning':
             toastType = 'text-bg-warning';
-            toastIcon = '<i class="fa-solid fa-exclamation me-1"></i>';
+            toastIcon = 'fa-solid fa-exclamation';
             break;
         default:
             toastType = 'text-bg-success';
-            toastIcon = '<i class="fa-solid fa-circle-check me-1"></i>';
+            toastIcon = 'fa-solid fa-circle-check';
     };
 
-    const toast = `<div id="${toastId}" class="toast align-items-center ${toastType}" role="alert" aria-live="assertive" aria-atomic="true">
-        <div class="d-flex">
-            <div class="toast-body">
-                <p class="mb-0 toast-message"><strong>${toastIcon}</strong>${toastMessage}</p>
-            </div>
-            <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></button>
-        </div>
-    </div>`;
+    const toast = document.createElement('div');
+    toast.id = toastId;
+    toast.className = `toast align-items-center ${toastType}`;
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+    toast.setAttribute('aria-atomic', 'true');
 
-    toastContainer.insertAdjacentHTML('beforeend', toast);
+    const flex = document.createElement('div');
+    flex.className = 'd-flex';
 
-    const toastElement = document.querySelector(`#${toastId}`);
-    const toastInstance = bootstrap.Toast.getOrCreateInstance(toastElement, { autohide: true });
+    const body = document.createElement('div');
+    body.className = 'toast-body';
+
+    const message = document.createElement('p');
+    message.className = 'mb-0 toast-message';
+
+    const strong = document.createElement('strong');
+
+    const icon = document.createElement('i');
+    icon.className = `${toastIcon} me-1`;
+    icon.setAttribute('aria-hidden', 'true');
+
+    strong.appendChild(icon);
+    message.appendChild(strong);
+    message.appendChild(document.createTextNode(toastMessage));
+
+    body.appendChild(message);
+
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'btn-close me-2 m-auto';
+    closeButton.setAttribute('data-bs-dismiss', 'toast');
+    closeButton.setAttribute('aria-label', 'Close');
+
+    const closeIcon = document.createElement('span');
+    closeIcon.className = 'fa-solid fa-xmark';
+    closeIcon.setAttribute('aria-hidden', 'true');
+
+    closeButton.appendChild(closeIcon);
+
+    flex.append(body, closeButton);
+    toast.appendChild(flex);
+
+    toastContainer.appendChild(toast);
+
+    const toastInstance = bootstrap.Toast.getOrCreateInstance(toast, {
+        autohide: true
+    });
 
     toastInstance.show();
 
-    // Remove toast after it has been hidden
-    toastElement.addEventListener('hidden.bs.toast', () => {
-        toastElement.remove();
+    toast.addEventListener('hidden.bs.toast', () => {
+        toast.remove();
     });
 };


### PR DESCRIPTION
## Description Of Changes

Refactor JavaScript that dynamically generates HTML to use native DOM
API methods such as createElement(), append(), textContent, and
setAttribute() instead of constructing HTML with template literals.

No functional changes are intended.

## Motivation and Context

This change reduces reliance on HTML string generation, improves
resistance to XSS vulnerabilities by treating dynamic content as text by
default, and aligns the codebase with secure coding best practices.

## Testing
Ensure all tests pass on PRs that use this.

### Operating Systems Testing
Dev VM 4. 

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Fixes #549
