### PR TITLE
(#553) Add fa-openid to CCM PurgeCSS Safelist

### DIFF
--- a/packages/build-tools/build/data/repository-config.ts
+++ b/packages/build-tools/build/data/repository-config.ts
@@ -179,7 +179,7 @@ repositoryConfig.ccm.purgeCss = {
         /^fill-(blue|pink|purple|green|red|yellow|orange|success|danger|info|primary)/,
         /^selected/,
         /^dt-column-header/,
-        /^fa-(brands|google|twitter|x-twitter|square-x-twitter|google|microsoft|facebook|facebook-f|square-facebook)/,
+        /^fa-(brands|facebook|facebook-f|google|microsoft|openid|square-facebook|square-x-twitter|twitter|x-twitter)/,
         /^alert-(warning|danger|success|info)/,
     ]
 };

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chocolatey-software/build-tools",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "Chocolatey Software build tools.",
     "author": "Chocolatey Software (https://chocolatey.org/)",
     "homepage": "https://github.com/chocolatey/choco-theme/blob/main/packages/build-tools#readme",


### PR DESCRIPTION
## Description Of Changes

- Add `fa-openid` to the `fa-(...)` PurgeCSS safelist regex used by the
  `ccm` repository config, and alphabetize the alternatives in that
  regex. Also drops a pre-existing duplicate `google` entry that had
  crept into the list.

## Motivation and Context

CCM PR #785 uses the `fa-openid` icon (noted by Steph in review), but
the PurgeCSS safelist for the `ccm` build target didn't include it, so
PurgeCSS would strip the class from the built CSS and the icon
wouldn't render. Adding it to the safelist keeps the icon's styles in
the final output.

## Testing

N/A: not run against a live CCM build in this session — this change
was verified by inspection only (confirming the regex now matches
`fa-openid` and that the existing entries are preserved). Recommend
building CCM's CSS locally and confirming the icon renders before
merging.

### Operating Systems Testing

N/A: build-tooling/config change, not OS-specific.

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked? N/A — no PowerShell touched.
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #553